### PR TITLE
optionally make a connected cellular map

### DIFF
--- a/rot.js
+++ b/rot.js
@@ -1,6 +1,6 @@
 /*
 	This is rot.js, the ROguelike Toolkit in JavaScript.
-	Version 0.5~dev, generated on Mon Mar 31 15:10:41 CEST 2014.
+	Version 0.5~dev, generated on Sat Apr 26 10:24:50 PDT 2014.
 */
 /**
  * @namespace Top-level ROT namespace
@@ -2189,7 +2189,8 @@ ROT.Map.Cellular = function(width, height, options) {
 	this._options = {
 		born: [5, 6, 7, 8],
 		survive: [4, 5, 6, 7, 8],
-		topology: 8
+		topology: 8,
+		connected: false
 	};
 	this.setOptions(options);
 	
@@ -2246,13 +2247,24 @@ ROT.Map.Cellular.prototype.create = function(callback) {
 				newMap[i][j] = 1;
 			} else if (!cur && born.indexOf(ncount) != -1) { /* born */
 				newMap[i][j] = 1;
-			}
-			
-			if (callback) { callback(i, j, newMap[i][j]); }
+			}			
 		}
 	}
 	
 	this._map = newMap;
+
+	// optinially connect every space
+	if (this._options.connected) {
+		this._completeMaze();	
+	}
+
+	if (callback) { 
+		for (var i = 0; i < this._width; i++) {
+			for (var j = 0; j < this._height; j++) {
+				callback(i, j, newMap[i][j]);
+			}
+		}
+	}
 }
 
 /**
@@ -2271,6 +2283,166 @@ ROT.Map.Cellular.prototype._getNeighbors = function(cx, cy) {
 	
 	return result;
 }
+
+/**
+ * Make sure every non-wall space is accessible.
+ */
+ROT.Map.Cellular.prototype._completeMaze = function() {
+	var allFreeSpace = [];
+	var notConnected = {};
+	// find all free space
+	for (var x = 0; x < this._width; x++) {
+		for (var y = 0; y < this._height; y++) {
+			if (this._freeSpace(x, y)) {
+				var p = [x, y];
+				notConnected[this._pointKey(p)] = p;
+				allFreeSpace.push([x, y]);
+			}
+		}
+	}
+	var start = allFreeSpace[ROT.RNG.getUniformInt(0, allFreeSpace.length - 1)];
+
+	var key = this._pointKey(start);
+	var connected = {};
+	connected[key] = start;
+	delete notConnected[key]
+
+	// find what's connected to the starting point
+	this._findConnected(connected, notConnected, [start]);
+
+	while(Object.keys(notConnected).length > 0) {
+
+		// find two points from notConnected to connected
+		var p = this._getFromTo(connected, notConnected);
+		var from = p[0]; // notConnected
+		var to = p[1]; // connected
+
+		// find everything connected to the starting point
+		var local = {};
+		local[this._pointKey(from)] = from;
+		this._findConnected(local, notConnected, [from], true);
+
+		// connect to a connected square
+		this._tunnelToConnected(to, from, connected, notConnected);
+
+		// now all of local is connected
+		for (var k in local) {
+			var pp = local[k];
+			this._map[pp[0]][pp[1]] = 0;
+			connected[k] = pp;
+			delete notConnected[k];
+		}
+	}
+}
+
+/**
+ * Find random points to connect. Search for the closest point in the larger space. 
+ * This is to minimize the length of the passage while maintaining good performance.
+ */
+ROT.Map.Cellular.prototype._getFromTo = function(connected, notConnected) {
+	var from, to, d;
+	var connectedKeys = Object.keys(connected);
+	var notConnectedKeys = Object.keys(notConnected);
+	for (var i = 0; i < 5; i++) {
+		if (connectedKeys.length < notConnectedKeys.length) {
+			var keys = connectedKeys;
+			to = connected[keys[ROT.RNG.getUniformInt(0, keys.length - 1)]]
+			from = this._getClosest(to, notConnected);
+		} else {
+			var keys = notConnectedKeys;
+			from = notConnected[keys[ROT.RNG.getUniformInt(0, keys.length - 1)]]
+			to = this._getClosest(from, connected);
+		}
+		d = (from[0] - to[0]) * (from[0] - to[0]) + (from[1] - to[1]) * (from[1] - to[1]);
+		if (d < 64) {
+			break;
+		}
+	}
+	// console.log(">>> connected=" + to + " notConnected=" + from + " dist=" + d);
+	return [from, to];
+}
+
+ROT.Map.Cellular.prototype._getClosest = function(point, space) {
+	var minPoint = null;
+	var minDist = null;
+	for (k in space) {
+		var p = space[k];
+		var d = (p[0] - point[0]) * (p[0] - point[0]) + (p[1] - point[1]) * (p[1] - point[1]);
+		if (minDist == null || d < minDist) {
+			minDist = d;
+			minPoint = p;
+		}
+	}
+	return minPoint;
+}
+
+ROT.Map.Cellular.prototype._findConnected = function(connected, notConnected, stack, keepNotConnected) {
+	while(stack.length > 0) {
+		var p = stack.splice(0, 1)[0];
+		var tests = [
+			[p[0] + 1, p[1]],
+			[p[0] - 1, p[1]],
+			[p[0],     p[1] + 1],
+			[p[0],     p[1] - 1]
+		];
+		for (var i = 0; i < tests.length; i++) {
+			var key = this._pointKey(tests[i]);
+			if (connected[key] == null && this._freeSpace(tests[i][0], tests[i][1])) {
+				connected[key] = tests[i];
+				if (!keepNotConnected) {
+					delete notConnected[key];
+				}
+				stack.push(tests[i]);
+			}
+		}
+	}
+}
+
+ROT.Map.Cellular.prototype._tunnelToConnected = function(to, from, connected, notConnected) {
+	var key = this._pointKey(from);
+	var a, b;
+	if (from[0] < to[0]) {
+		a = from;
+		b = to;
+	} else {
+		a = to;
+		b = from;
+	}
+	for (var xx = a[0]; xx <= b[0]; xx++) {
+		this._map[xx][a[1]] = 0;
+		var p = [xx, a[1]];
+		var pkey = this._pointKey(p);
+		connected[pkey] = p;
+		delete notConnected[pkey];
+	}
+
+	// x is now fixed
+	var x = b[0];
+
+	if (from[1] < to[1]) {
+		a = from;
+		b = to;
+	} else {
+		a = to;
+		b = from;
+	}
+	for (var yy = a[1]; yy < b[1]; yy++) {
+		this._map[x][yy] = 0;
+		var p = [x, yy];
+		var pkey = this._pointKey(p);
+		connected[pkey] = p;
+		delete notConnected[pkey];
+	}
+}
+
+ROT.Map.Cellular.prototype._freeSpace = function(x, y) {
+	return x >= 0 && x < this._width && y >= 0 && y < this._height && this._map[x][y] != 1;
+}
+
+ROT.Map.Cellular.prototype._pointKey = function(p) {
+	return p[0] + "." + p[1];
+}
+
 /**
  * @class Dungeon map: has rooms and corridors
  * @augments ROT.Map

--- a/src/map/cellular.js
+++ b/src/map/cellular.js
@@ -13,7 +13,8 @@ ROT.Map.Cellular = function(width, height, options) {
 	this._options = {
 		born: [5, 6, 7, 8],
 		survive: [4, 5, 6, 7, 8],
-		topology: 8
+		topology: 8,
+		connected: false
 	};
 	this.setOptions(options);
 	
@@ -70,13 +71,24 @@ ROT.Map.Cellular.prototype.create = function(callback) {
 				newMap[i][j] = 1;
 			} else if (!cur && born.indexOf(ncount) != -1) { /* born */
 				newMap[i][j] = 1;
-			}
-			
-			if (callback) { callback(i, j, newMap[i][j]); }
+			}			
 		}
 	}
 	
 	this._map = newMap;
+
+	// optinially connect every space
+	if (this._options.connected) {
+		this._completeMaze();	
+	}
+
+	if (callback) { 
+		for (var i = 0; i < this._width; i++) {
+			for (var j = 0; j < this._height; j++) {
+				callback(i, j, newMap[i][j]);
+			}
+		}
+	}
 }
 
 /**
@@ -95,3 +107,163 @@ ROT.Map.Cellular.prototype._getNeighbors = function(cx, cy) {
 	
 	return result;
 }
+
+/**
+ * Make sure every non-wall space is accessible.
+ */
+ROT.Map.Cellular.prototype._completeMaze = function() {
+	var allFreeSpace = [];
+	var notConnected = {};
+	// find all free space
+	for (var x = 0; x < this._width; x++) {
+		for (var y = 0; y < this._height; y++) {
+			if (this._freeSpace(x, y)) {
+				var p = [x, y];
+				notConnected[this._pointKey(p)] = p;
+				allFreeSpace.push([x, y]);
+			}
+		}
+	}
+	var start = allFreeSpace[ROT.RNG.getUniformInt(0, allFreeSpace.length - 1)];
+
+	var key = this._pointKey(start);
+	var connected = {};
+	connected[key] = start;
+	delete notConnected[key]
+
+	// find what's connected to the starting point
+	this._findConnected(connected, notConnected, [start]);
+
+	while(Object.keys(notConnected).length > 0) {
+
+		// find two points from notConnected to connected
+		var p = this._getFromTo(connected, notConnected);
+		var from = p[0]; // notConnected
+		var to = p[1]; // connected
+
+		// find everything connected to the starting point
+		var local = {};
+		local[this._pointKey(from)] = from;
+		this._findConnected(local, notConnected, [from], true);
+
+		// connect to a connected square
+		this._tunnelToConnected(to, from, connected, notConnected);
+
+		// now all of local is connected
+		for (var k in local) {
+			var pp = local[k];
+			this._map[pp[0]][pp[1]] = 0;
+			connected[k] = pp;
+			delete notConnected[k];
+		}
+	}
+}
+
+/**
+ * Find random points to connect. Search for the closest point in the larger space. 
+ * This is to minimize the length of the passage while maintaining good performance.
+ */
+ROT.Map.Cellular.prototype._getFromTo = function(connected, notConnected) {
+	var from, to, d;
+	var connectedKeys = Object.keys(connected);
+	var notConnectedKeys = Object.keys(notConnected);
+	for (var i = 0; i < 5; i++) {
+		if (connectedKeys.length < notConnectedKeys.length) {
+			var keys = connectedKeys;
+			to = connected[keys[ROT.RNG.getUniformInt(0, keys.length - 1)]]
+			from = this._getClosest(to, notConnected);
+		} else {
+			var keys = notConnectedKeys;
+			from = notConnected[keys[ROT.RNG.getUniformInt(0, keys.length - 1)]]
+			to = this._getClosest(from, connected);
+		}
+		d = (from[0] - to[0]) * (from[0] - to[0]) + (from[1] - to[1]) * (from[1] - to[1]);
+		if (d < 64) {
+			break;
+		}
+	}
+	// console.log(">>> connected=" + to + " notConnected=" + from + " dist=" + d);
+	return [from, to];
+}
+
+ROT.Map.Cellular.prototype._getClosest = function(point, space) {
+	var minPoint = null;
+	var minDist = null;
+	for (k in space) {
+		var p = space[k];
+		var d = (p[0] - point[0]) * (p[0] - point[0]) + (p[1] - point[1]) * (p[1] - point[1]);
+		if (minDist == null || d < minDist) {
+			minDist = d;
+			minPoint = p;
+		}
+	}
+	return minPoint;
+}
+
+ROT.Map.Cellular.prototype._findConnected = function(connected, notConnected, stack, keepNotConnected) {
+	while(stack.length > 0) {
+		var p = stack.splice(0, 1)[0];
+		var tests = [
+			[p[0] + 1, p[1]],
+			[p[0] - 1, p[1]],
+			[p[0],     p[1] + 1],
+			[p[0],     p[1] - 1]
+		];
+		for (var i = 0; i < tests.length; i++) {
+			var key = this._pointKey(tests[i]);
+			if (connected[key] == null && this._freeSpace(tests[i][0], tests[i][1])) {
+				connected[key] = tests[i];
+				if (!keepNotConnected) {
+					delete notConnected[key];
+				}
+				stack.push(tests[i]);
+			}
+		}
+	}
+}
+
+ROT.Map.Cellular.prototype._tunnelToConnected = function(to, from, connected, notConnected) {
+	var key = this._pointKey(from);
+	var a, b;
+	if (from[0] < to[0]) {
+		a = from;
+		b = to;
+	} else {
+		a = to;
+		b = from;
+	}
+	for (var xx = a[0]; xx <= b[0]; xx++) {
+		this._map[xx][a[1]] = 0;
+		var p = [xx, a[1]];
+		var pkey = this._pointKey(p);
+		connected[pkey] = p;
+		delete notConnected[pkey];
+	}
+
+	// x is now fixed
+	var x = b[0];
+
+	if (from[1] < to[1]) {
+		a = from;
+		b = to;
+	} else {
+		a = to;
+		b = from;
+	}
+	for (var yy = a[1]; yy < b[1]; yy++) {
+		this._map[x][yy] = 0;
+		var p = [x, yy];
+		var pkey = this._pointKey(p);
+		connected[pkey] = p;
+		delete notConnected[pkey];
+	}
+}
+
+ROT.Map.Cellular.prototype._freeSpace = function(x, y) {
+	return x >= 0 && x < this._width && y >= 0 && y < this._height && this._map[x][y] != 1;
+}
+
+ROT.Map.Cellular.prototype._pointKey = function(p) {
+	return p[0] + "." + p[1];
+}
+


### PR DESCRIPTION
Hello, please consider this patch to rot.js that optionally creates a connected cellular map. In such a map every non-wall location is accessible. To use it, do:

var map = new ROT.Map.Cellular(width, height, { connected: true });

and otherwise use as you would with a cellular map.

Thanks!
