### PR TITLE
fixed the full-width issue in drawText

### DIFF
--- a/src/display/display.js
+++ b/src/display/display.js
@@ -187,11 +187,20 @@ ROT.Display.prototype.drawText = function(x, y, text, maxWidth) {
 		var token = tokens.shift();
 		switch (token.type) {
 			case ROT.Text.TYPE_TEXT:
+				var isSpace = false;
 				for (var i=0;i<token.value.length;i++) {
-					if(escape(token.value.charAt(i)).indexOf("%u") >= 0){ // a full-width character
-						cx++;
+					var uc = token.value.charCodeAt(i);
+					if((uc > 0xff && uc < 0xff61) || (uc > 0xffdc && uc < 0xffe8) && uc > 0xffee) { // a full-width character
+						if (!isSpace) { 
+							// If the previous of full-width char is a space, 
+							// there will be no need for extra width.
+							cx++;
+						}
 					}
-					this.draw(cx++, cy, token.value.charAt(i), fg, bg);
+					var c = token.value.charAt(i)
+					this.draw(cx++, cy, c, fg, bg);
+					// Space, whatever full-width or half-width char, both are OK.
+					isSpace = (c.charCodeAt(0) == 0x20 || c.charCodeAt(0) == 0x3000);
 				}
 			break;
 


### PR DESCRIPTION
The mechanism:
1. The previous char is space(both full or half width), there will be no need for an extra position;
2. Otherwise, add an extra position for placing the full-width char.
