### PR TITLE
added support for tile colours

### DIFF
--- a/manual/pages/display.html
+++ b/manual/pages/display.html
@@ -143,3 +143,37 @@ tileSet.onload = function() {
 	display.draw(0, 0, ["#", "@"]);
 }
 </div>
+
+<h3>Coloring tiles</h3>
+
+<div class="example">
+var tileSet = document.createElement("img");
+tileSet.src = "tiles.png";
+
+var options = {
+	layout: "tile",
+	tileWidth: 64,
+	tileHeight: 64,
+	tileSet: tileSet,
+	tileMap: {
+		"@": [0, 0],
+		"#": [0, 64],
+		"a": [64, 0],
+		"!": [64, 64]
+	},
+	width: 3,
+	height: 3,
+	tileColor: true
+}
+var display = new ROT.Display(options);
+SHOW(display.getContainer());
+
+tileSet.onload = function() {
+    display.draw(1, 1, "@", "transparent");
+    display.draw(0, 0, "#", "white");
+    display.draw(0, 1, "#", "blue");
+    display.draw(1, 0, "@", "green", "red");
+
+    display.drawText(0,3,'#@#@')
+}
+</div>

--- a/rot.js
+++ b/rot.js
@@ -1289,11 +1289,37 @@ ROT.Display.Tile.prototype.draw = function(data, clearBefore) {
 		var tile = this._options.tileMap[chars[i]];
 		if (!tile) { throw new Error("Char '" + chars[i] + "' not found in tileMap"); }
 		
-		this._context.drawImage(
+		var bufferCanvas = document.createElement("canvas");
+		bufferCanvas.width = tileWidth;
+		bufferCanvas.height = tileHeight;
+
+		var buffer = bufferCanvas.getContext("2d");
+
+		buffer.clearRect(0, 0, tileWidth, tileHeight)
+
+		buffer.drawImage(
 			this._options.tileSet,
 			tile[0], tile[1], tileWidth, tileHeight,
-			x*tileWidth, y*tileHeight, tileWidth, tileHeight
+			0, 0, tileWidth, tileHeight
 		);
+
+		if (fg != 'transparent') {
+			buffer.fillStyle = fg;
+			buffer.globalCompositeOperation = "source-atop";
+			buffer.fillRect(0, 0, tileWidth, tileHeight);
+		}
+
+		if (bg != 'transparent') {
+			buffer.fillStyle = bg;
+			buffer.globalCompositeOperation = "destination-atop";
+			buffer.fillRect(0, 0, tileWidth, tileHeight);
+		}
+
+		buffer.restore();
+
+		this._context.drawImage(bufferCanvas, x*tileWidth, y*tileHeight, tileWidth, tileHeight)
+
+		bufferCanvas = null
 	}
 }
 

--- a/src/display/display.js
+++ b/src/display/display.js
@@ -19,6 +19,7 @@
 ROT.Display = function(options) {
 	var canvas = document.createElement("canvas");
 	this._context = canvas.getContext("2d");
+	this._buffer = document.createElement("canvas");
 	this._data = {};
 	this._dirty = false; /* false = nothing, true = all, object = dirty cells */
 	this._options = {};
@@ -39,7 +40,8 @@ ROT.Display = function(options) {
 		tileWidth: 32,
 		tileHeight: 32,
 		tileMap: {},
-		tileSet: null
+		tileSet: null,
+		tileColor: false
 	};
 	for (var p in options) { defaultOptions[p] = options[p]; }
 	this.setOptions(defaultOptions);
@@ -80,7 +82,7 @@ ROT.Display.prototype.setOptions = function(options) {
 
 		var font = (this._options.fontStyle ? this._options.fontStyle + " " : "") + this._options.fontSize + "px " + this._options.fontFamily;
 		this._context.font = font;
-		this._backend.compute(this._options);
+		this._backend.compute(this._options, this._buffer);
 		this._context.font = font;
 		this._context.textAlign = "center";
 		this._context.textBaseline = "middle";

--- a/src/display/tile.js
+++ b/src/display/tile.js
@@ -9,10 +9,13 @@ ROT.Display.Tile = function(context) {
 }
 ROT.Display.Tile.extend(ROT.Display.Rect);
 
-ROT.Display.Tile.prototype.compute = function(options) {
+ROT.Display.Tile.prototype.compute = function(options, buffer) {
 	this._options = options;
+	this._buffer = buffer;
 	this._context.canvas.width = options.width * options.tileWidth;
 	this._context.canvas.height = options.height * options.tileHeight;
+	this._buffer.width = options.tileWidth;
++	this._buffer.height = options.tileHeight;
 }
 
 ROT.Display.Tile.prototype.draw = function(data, clearBefore) {

--- a/src/display/tile.js
+++ b/src/display/tile.js
@@ -28,7 +28,11 @@ ROT.Display.Tile.prototype.draw = function(data, clearBefore) {
 	if (clearBefore) {
 		var b = this._options.border;
 		this._context.fillStyle = bg;
-		this._context.fillRect(x*tileWidth, y*tileHeight, tileWidth, tileHeight);
+
+		if (this._options.tileColor) {this._context.clearRect(x*tileWidth, y*tileHeight, tileWidth, tileHeight);} else {
+			this._context.fillRect(x*tileWidth, y*tileHeight, tileWidth, tileHeight);
+		}
+		
 	}
 
 	if (!ch) { return; }
@@ -38,10 +42,7 @@ ROT.Display.Tile.prototype.draw = function(data, clearBefore) {
 		var tile = this._options.tileMap[chars[i]];
 		if (!tile) { throw new Error("Char '" + chars[i] + "' not found in tileMap"); }
 		
-		var bufferCanvas = document.createElement("canvas");
-		bufferCanvas.width = tileWidth;
-		bufferCanvas.height = tileHeight;
-
+		var bufferCanvas = this._buffer
 		var buffer = bufferCanvas.getContext("2d");
 
 		buffer.clearRect(0, 0, tileWidth, tileHeight)
@@ -52,24 +53,20 @@ ROT.Display.Tile.prototype.draw = function(data, clearBefore) {
 			0, 0, tileWidth, tileHeight
 		);
 
-		if (fg != 'transparent') {
+		if (fg != 'transparent' && this._options.tileColor) {
 			buffer.fillStyle = fg;
 			buffer.globalCompositeOperation = "source-atop";
 			buffer.fillRect(0, 0, tileWidth, tileHeight);
 		}
 
-		if (bg != 'transparent') {
+		if (bg != 'transparent' && this._options.tileColor) {
 			buffer.fillStyle = bg;
 			buffer.globalCompositeOperation = "destination-atop";
 			buffer.fillRect(0, 0, tileWidth, tileHeight);
 		}
 
-		buffer.restore();
-
 		this._context.drawImage(bufferCanvas, x*tileWidth, y*tileHeight, tileWidth, tileHeight)
 
-		bufferCanvas = null
-		
 	}
 }
 

--- a/src/display/tile.js
+++ b/src/display/tile.js
@@ -38,11 +38,38 @@ ROT.Display.Tile.prototype.draw = function(data, clearBefore) {
 		var tile = this._options.tileMap[chars[i]];
 		if (!tile) { throw new Error("Char '" + chars[i] + "' not found in tileMap"); }
 		
-		this._context.drawImage(
+		var bufferCanvas = document.createElement("canvas");
+		bufferCanvas.width = tileWidth;
+		bufferCanvas.height = tileHeight;
+
+		var buffer = bufferCanvas.getContext("2d");
+
+		buffer.clearRect(0, 0, tileWidth, tileHeight)
+
+		buffer.drawImage(
 			this._options.tileSet,
 			tile[0], tile[1], tileWidth, tileHeight,
-			x*tileWidth, y*tileHeight, tileWidth, tileHeight
+			0, 0, tileWidth, tileHeight
 		);
+
+		if (fg != 'transparent') {
+			buffer.fillStyle = fg;
+			buffer.globalCompositeOperation = "source-atop";
+			buffer.fillRect(0, 0, tileWidth, tileHeight);
+		}
+
+		if (bg != 'transparent') {
+			buffer.fillStyle = bg;
+			buffer.globalCompositeOperation = "destination-atop";
+			buffer.fillRect(0, 0, tileWidth, tileHeight);
+		}
+
+		buffer.restore();
+
+		this._context.drawImage(bufferCanvas, x*tileWidth, y*tileHeight, tileWidth, tileHeight)
+
+		bufferCanvas = null
+		
 	}
 }
 


### PR DESCRIPTION
This uses globalCompositeOperation to allow foreground/background colours on tile displays. I'm using this to render bitmap fonts. It works with draw & drawtext. To render the image without colours, set both foreground and background to 'transparent'.