### PR TITLE
replace &minus; with plain `-`, as per #49

### DIFF
--- a/manual/pages/hex/indexing.html
+++ b/manual/pages/hex/indexing.html
@@ -11,7 +11,7 @@
 <ul class="comparison">
 	<li><strong>Distance: </strong><code>sign(dx) == sign(dy) ? max(|dx|, |dy|) : |dx|+|dy|</code></li>
 	<li class="bad"><strong>Storage: </strong>2D array stores a parallelogram area</li>
-	<li class="good"><strong>Neighbors: </strong><code>(&minus;1,0); (1,0); (&minus;1,&minus;1); (1,&minus;1); (&minus;1,1); (1,1)</code></li>
+	<li class="good"><strong>Neighbors: </strong><code>(-1,0); (1,0); (-1,-1); (1,-1); (-1,1); (1,1)</code></li>
 	<li class="good"><strong>Straight lines: </strong><code>(x &pm; n, y); (x &pm; n, y &pm; n); (x &mp; n, y &pm; n)</code></li>
 </ul>
 
@@ -41,7 +41,7 @@ display.draw(5, 3, "3,3", "", "#ccc");
 <ul class="comparison">
 	<li class="bad"><strong>Distance: </strong><code>max(|dy|, |dx| + floor(|dy|/2) + penalty); penalty = ( (even(y1) &amp;&amp; odd(y2) &amp;&amp; (x1 &lt; x2)) || (even(y2) &amp;&amp; odd(y1) &amp;&amp; (x2 &lt; x1)) ) ? 1 : 0</code></li>
 	<li class="good"><strong>Storage: </strong> visually corresponds to a 2D array</li>
-	<li class="bad"><strong>Neighbors: </strong>even lines <code>(&minus;1,0); (1,0); (&minus;1,&minus;1); (0,&minus;1); (&minus;1,1); (0,1)</code>, odd lines <code>(&minus;1,0); (1,0); (0,&minus;1); (1,&minus;1); (0,1); (1,1)</code></li>
+	<li class="bad"><strong>Neighbors: </strong>even lines <code>(-1,0); (1,0); (-1,-1); (0,-1); (-1,1); (0,1)</code>, odd lines <code>(-1,0); (1,0); (0,-1); (1,-1); (0,1); (1,1)</code></li>
 	<li class="bad"><strong>Straight lines: </strong><code>(x &pm; n, y); (x &pm; n/2, y &pm; n); (x &pm; n/2, y &pm; n)</code>, even and odd lines use different rounding</li>
 </ul>
 
@@ -71,7 +71,7 @@ display.draw(5, 3, "2,3", "", "#ccc");
 <ul class="comparison">
 	<li><strong>Distance: </strong><code>|dy| + max(0, (|dx|&minus;|dy|)/2)</code></li>
 	<li class="bad"><strong>Storage: </strong>needs twice the storage &ndash; half of the possible coordinate values (with odd sum) is not used at all.</li>
-	<li class="good"><strong>Neighbors: </strong><code>(&minus;2,0); (2,0); (&minus;1,&minus;1); (1,1); (&minus;1,1); (1,&minus;1)</code></li>
+	<li class="good"><strong>Neighbors: </strong><code>(-2,0); (2,0); (-1,-1); (1,1); (-1,1); (1,-1)</code></li>
 	<li class="good"><strong>Straight lines: </strong><code>(x &pm; 2n, y); (x &pm; n, y &pm; n); (x &mp; n, y &pm; n)</code></li>
 	<li><strong>Remarks: </strong>x+y is always even.</li>
 </ul>
@@ -102,7 +102,7 @@ display.draw(5, 3, "5,3", "", "#ccc");
 <ul class="comparison">
 	<li class="good"><strong>Distance: </strong><code>max(|dx|,|dy|,|dz|)</code></li>
 	<li class="bad"><strong>Storage: </strong>WTF</li>
-	<li class="good"><strong>Neighbors: </strong><code>(1,0,&minus;1); (&minus;1,0,1); (0,1,&minus;1); (0,&minus;1,1); (1,&minus;1,0); (&minus;1,1,0)</code></li>
+	<li class="good"><strong>Neighbors: </strong><code>(1,0,-1); (-1,0,1); (0,1,-1); (0,-1,1); (1,-1,0); (-1,1,0)</code></li>
 	<li class="good"><strong>Straight lines: </strong><code>(x &pm; n, y, z &mp; n); (x &pm; n, y &mp; n, z); (x, y &pm; n, z &mp; n)</code></li>
 	<li><strong>Remarks: </strong>x+y+z = 0</li>
 </ul>


### PR DESCRIPTION
As discussed, &minus; entities was replaced by basic minuses to prevent hard to spot errors when copy-pasting offsets to source code.