### PR TITLE
Add a link to WebJars

### DIFF
--- a/manual/pages/intro.html
+++ b/manual/pages/intro.html
@@ -8,6 +8,8 @@
 
 <p>There is also a <a href="https://raw.github.com/ondras/rot.js/master/rot.min.js">minified version</a> available, compressed using Google's Closure compiler. This file is much smaller and suitable for production/deployment.</p>
 
+<p>If you're using JVM-based build, you can setup the build system to download rot.js from <a href="http://www.webjars.org/">WebJars</a>.</p>
+
 <h2>Examples</h2>
 
 <p>This manual is interactive: click on any example to modify its source and re-run it by clicking elsewhere. Use the navigation menu to the left to access other chapters of this manual.


### PR DESCRIPTION
Add a link to WebJars from the introduction section.

Unfortunately, there is no direct way to directly link rot.js on the WebJars site so I've decided to simply link their main page. It will be sufficient for guys who use WebJars :)

We've already used this jar-version of rot.js in the [Keter](https://github.com/codingteam/Keter/) project and it works well.