### PR TITLE
Fix logic in ROT.Map.Rogue to use parens per #62

### DIFF
--- a/src/map/rogue.js
+++ b/src/map/rogue.js
@@ -28,7 +28,7 @@ ROT.Map.Rogue = function(width, height, options) {
 	if (!this._options.hasOwnProperty("roomWidth")) {
 		this._options["roomWidth"] = this._calculateRoomSize(this._width, this._options["cellWidth"]);
 	}
-	if (!this._options.hasOwnProperty["roomHeight"]) {
+	if (!this._options.hasOwnProperty("roomHeight")) {
 		this._options["roomHeight"] = this._calculateRoomSize(this._height, this._options["cellHeight"]);
 	}
 	


### PR DESCRIPTION
Changed from brackets to parens so as to prevent !this._options.hasOwnProperty["roomHeight"] from always returning true (!undefined). No other changes made.

Before:

if (!this._options.hasOwnProperty["roomHeight"]) {
		this._options["roomHeight"] = this._calculateRoomSize(this._height, this._options["cellHeight"]);
	}

After:

if (!this._options.hasOwnProperty("roomHeight")) {
		this._options["roomHeight"] = this._calculateRoomSize(this._height, this._options["cellHeight"]);
	}