### PR TITLE
Spelling fix

### DIFF
--- a/manual/pages/tiles.html
+++ b/manual/pages/tiles.html
@@ -38,7 +38,7 @@ tileSet.onload = function() {
 
 <h2>Multiple tiles at one place</h2>
 
-<p>It is possible to draw multiple tiles at one place: just pass an array of chars as the thir argument to <code>Display.prototype.draw</code>. This can be used in other (non-tiled) backends as well, but brings almost no real usability.</p>
+<p>It is possible to draw multiple tiles at one place: just pass an array of chars as the third argument to <code>Display.prototype.draw</code>. This can be used in other (non-tiled) backends as well, but brings almost no real usability.</p>
 
 <div class="example">
 var tileSet = document.createElement("img");


### PR DESCRIPTION
In the tiles manual page there was a missing ‘d’ for the word ‘third’.