### PR TITLE
Make eventToPosition scale to client dimensions

### DIFF
--- a/rot.js
+++ b/rot.js
@@ -1,6 +1,6 @@
 /*
 	This is rot.js, the ROguelike Toolkit in JavaScript.
-	Version 0.6~dev, generated on Thu Sep  3 07:14:19 CEST 2015.
+	Version 0.6~dev, generated on Fri Jan 29 21:37:11 EST 2016.
 */
 /**
  * @namespace Top-level ROT namespace
@@ -844,6 +844,9 @@ ROT.Display.prototype.eventToPosition = function(e) {
 	x -= rect.left;
 	y -= rect.top;
 	
+	x *= this._context.canvas.width / this._context.canvas.clientWidth;
+	y *= this._context.canvas.height / this._context.canvas.clientHeight;
+
 	if (x < 0 || y < 0 || x >= this._context.canvas.width || y >= this._context.canvas.height) { return [-1, -1]; }
 
 	return this._backend.eventToPosition(x, y);

--- a/src/display/display.js
+++ b/src/display/display.js
@@ -148,6 +148,9 @@ ROT.Display.prototype.eventToPosition = function(e) {
 	x -= rect.left;
 	y -= rect.top;
 	
+	x *= this._context.canvas.width / this._context.canvas.clientWidth;
+	y *= this._context.canvas.height / this._context.canvas.clientHeight;
+
 	if (x < 0 || y < 0 || x >= this._context.canvas.width || y >= this._context.canvas.height) { return [-1, -1]; }
 
 	return this._backend.eventToPosition(x, y);


### PR DESCRIPTION
Couldn't figure out how to write a spec for this, but it comes into play when the container canvas is scaled with a percentage value. The change can be seen comparing

  original: http://tps12.github.io/rot.js/scale-demo-original.html

to

  modified: http://tps12.github.io/rot.js/scale-demo-modified.html