### PR TITLE
Adding tiebreaking to A*

### DIFF
--- a/rot.js
+++ b/rot.js
@@ -1,6 +1,6 @@
 /*
 	This is rot.js, the ROguelike Toolkit in JavaScript.
-	Version 0.6~dev, generated on Thu Mar  3 16:27:15 PST 2016.
+	Version 0.6~dev, generated on Thu Mar 31 23:30:04 EDT 2016.
 */
 /**
  * @namespace Top-level ROT namespace
@@ -5276,12 +5276,13 @@ ROT.Path.AStar.prototype.compute = function(fromX, fromY, callback) {
 }
 
 ROT.Path.AStar.prototype._add = function(x, y, prev) {
+	var h = this._distance(x, y);
 	var obj = {
 		x: x,
 		y: y,
 		prev: prev,
 		g: (prev ? prev.g+1 : 0),
-		h: this._distance(x, y)
+		h: h
 	}
 	this._done[x+","+y] = obj;
 	
@@ -5290,7 +5291,8 @@ ROT.Path.AStar.prototype._add = function(x, y, prev) {
 	var f = obj.g + obj.h;
 	for (var i=0;i<this._todo.length;i++) {
 		var item = this._todo[i];
-		if (f < item.g + item.h) {
+		var itemF = item.g + item.h;
+		if (f < itemF || (f == itemF && h < item.h)) {
 			this._todo.splice(i, 0, obj);
 			return;
 		}

--- a/src/path/astar.js
+++ b/src/path/astar.js
@@ -49,12 +49,13 @@ ROT.Path.AStar.prototype.compute = function(fromX, fromY, callback) {
 }
 
 ROT.Path.AStar.prototype._add = function(x, y, prev) {
+	var h = this._distance(x, y);
 	var obj = {
 		x: x,
 		y: y,
 		prev: prev,
 		g: (prev ? prev.g+1 : 0),
-		h: this._distance(x, y)
+		h: h
 	}
 	this._done[x+","+y] = obj;
 	
@@ -63,7 +64,8 @@ ROT.Path.AStar.prototype._add = function(x, y, prev) {
 	var f = obj.g + obj.h;
 	for (var i=0;i<this._todo.length;i++) {
 		var item = this._todo[i];
-		if (f < item.g + item.h) {
+		var itemF = item.g + item.h;
+		if (f < itemF || (f == itemF && h < item.h)) {
 			this._todo.splice(i, 0, obj);
 			return;
 		}

--- a/tests/spec/path.js
+++ b/tests/spec/path.js
@@ -59,9 +59,13 @@ describe("Path", function() {
 		if (x<0 || y<0 || x>=MAP6.length || y>=MAP6[0].length) { return false; }
 		return (MAP6[x][y] == 0);
 	}
+
+	var VISITS = 0;
+	var PASSABLE_CALLBACK_VISIT = function(x, y) { VISITS++; return true; }
 	
 	beforeEach(function() {
 		PATH = [];
+		VISITS = 0;
 	});
 	
 	
@@ -150,6 +154,12 @@ describe("Path", function() {
 			it("should survive non-existant path X", function() {
 				astar.compute(X[0], X[1], PATH_CALLBACK);
 				expect(PATH.length).toEqual(0);
+			});
+
+			it("should efficiently compute path",function(){
+				var open_astar = new ROT.Path.AStar(0,0, PASSABLE_CALLBACK_VISIT);
+				open_astar.compute(50,0, PATH_CALLBACK);
+				expect(VISITS).toEqual(400);
 			});
 		}); /* 8-topology */
 


### PR DESCRIPTION
Found that small tweaks to A* can dramatically alter the performance in certain cases (linear visits in size of path down from squared). I wrote a few notes with demo [here](http://humbit.com/pathfinding/test.html). I tried adding the least obtrusive of the changes (tiebreaking when f scores are equal) and attempted to write a test for it.

This is my first pull request for anything so I apologize if I'm missing something obvious.