### PR TITLE
Clean up ROT.Map.Rogue

### DIFF
--- a/src/map/rogue.js
+++ b/src/map/rogue.js
@@ -6,297 +6,283 @@
  * @param {int} [height=ROT.DEFAULT_HEIGHT]
  * @param {object} [options] Options
  * @param {int[]} [options.cellWidth=3] Number of cells to create on the horizontal (number of rooms horizontally)
- * @param {int[]} [options.cellHeight=3] Number of cells to create on the vertical (number of rooms vertically) 
+ * @param {int[]} [options.cellHeight=3] Number of cells to create on the vertical (number of rooms vertically)
  * @param {int} [options.roomWidth] Room min and max width - normally set auto-magically via the constructor.
- * @param {int} [options.roomHeight] Room min and max height - normally set auto-magically via the constructor. 
+ * @param {int} [options.roomHeight] Room min and max height - normally set auto-magically via the constructor.
  */
-ROT.Map.Rogue = function(width, height, options) {
+ROT.Map.Rogue = function (width, height, options) {
 	ROT.Map.call(this, width, height);
-	
+
 	this._options = {
 		cellWidth: 3,  // NOTE to self, these could probably work the same as the roomWidth/room Height values
 		cellHeight: 3  //     ie. as an array with min-max values for each direction....
-	}
-	
+	};
+
 	for (var p in options) { this._options[p] = options[p]; }
-	
+
 	/*
-	Set the room sizes according to the over-all width of the map, 
-	and the cell sizes. 
+	Set the room sizes according to the over-all width of the map,
+	and the cell sizes.
 	*/
-	
 	if (!this._options.hasOwnProperty("roomWidth")) {
 		this._options["roomWidth"] = this._calculateRoomSize(this._width, this._options["cellWidth"]);
 	}
 	if (!this._options.hasOwnProperty("roomHeight")) {
 		this._options["roomHeight"] = this._calculateRoomSize(this._height, this._options["cellHeight"]);
 	}
-	
-}
 
-ROT.Map.Rogue.extend(ROT.Map); 
+};
+
+ROT.Map.Rogue.extend(ROT.Map);
 
 /**
  * @see ROT.Map#create
  */
-ROT.Map.Rogue.prototype.create = function(callback) {
+ROT.Map.Rogue.prototype.create = function (callback) {
 	this.map = this._fillMap(1);
 	this.rooms = [];
 	this.connectedCells = [];
-	
+
 	this._initRooms();
 	this._connectRooms();
 	this._connectUnconnectedRooms();
 	this._createRandomRoomConnections();
 	this._createRooms();
 	this._createCorridors();
-	
+
 	if (callback) {
 		for (var i = 0; i < this._width; i++) {
 			for (var j = 0; j < this._height; j++) {
-				callback(i, j, this.map[i][j]);   
+				callback(i, j, this.map[i][j]);
 			}
 		}
 	}
-	
-	return this;
-}
 
-ROT.Map.Rogue.prototype._calculateRoomSize = function(size, cell) {
+	return this;
+};
+
+ROT.Map.Rogue.prototype._calculateRoomSize = function (size, cell) {
 	var max = Math.floor((size/cell) * 0.8);
 	var min = Math.floor((size/cell) * 0.25);
-	if (min < 2) min = 2;
-	if (max < 2) max = 2;
+	if (min < 2) { min = 2; }
+	if (max < 2) { max = 2; }
 	return [min, max];
-}
+};
 
-ROT.Map.Rogue.prototype._initRooms = function () { 
-	// create rooms array. This is the "grid" list from the algo.  
-	for (var i = 0; i < this._options.cellWidth; i++) {  
+ROT.Map.Rogue.prototype._initRooms = function () {
+	// create rooms array. This is the "grid" list from the algo.
+	for (var i = 0; i < this._options.cellWidth; i++) {
 		this.rooms.push([]);
 		for(var j = 0; j < this._options.cellHeight; j++) {
 			this.rooms[i].push({"x":0, "y":0, "width":0, "height":0, "connections":[], "cellx":i, "celly":j});
 		}
 	}
-}
+};
 
-ROT.Map.Rogue.prototype._connectRooms = function() {
+ROT.Map.Rogue.prototype._connectRooms = function () {
 	//pick random starting grid
 	var cgx = ROT.RNG.getUniformInt(0, this._options.cellWidth-1);
 	var cgy = ROT.RNG.getUniformInt(0, this._options.cellHeight-1);
-	
+
 	var idx;
 	var ncgx;
 	var ncgy;
-	
+
 	var found = false;
 	var room;
 	var otherRoom;
-	
+
 	// find  unconnected neighbour cells
 	do {
-	
-		//var dirToCheck = [0,1,2,3,4,5,6,7];
-		var dirToCheck = [0,2,4,6];
+
+		//var dirToCheck = [0, 1, 2, 3, 4, 5, 6, 7];
+		var dirToCheck = [0, 2, 4, 6];
 		dirToCheck = dirToCheck.randomize();
-		
+
 		do {
 			found = false;
 			idx = dirToCheck.pop();
-			
-			
+
 			ncgx = cgx + ROT.DIRS[8][idx][0];
 			ncgy = cgy + ROT.DIRS[8][idx][1];
-			
-			if(ncgx < 0 || ncgx >= this._options.cellWidth) continue;
-			if(ncgy < 0 || ncgy >= this._options.cellHeight) continue;
-			
+
+			if (ncgx < 0 || ncgx >= this._options.cellWidth) { continue; }
+			if (ncgy < 0 || ncgy >= this._options.cellHeight) { continue; }
+
 			room = this.rooms[cgx][cgy];
-			
-			if(room["connections"].length > 0)
-			{
-				// as long as this room doesn't already coonect to me, we are ok with it. 
-				if(room["connections"][0][0] == ncgx &&
-				room["connections"][0][1] == ncgy)
-				{
+
+			if (room["connections"].length > 0) {
+				// as long as this room doesn't already coonect to me, we are ok with it.
+				if (room["connections"][0][0] == ncgx && room["connections"][0][1] == ncgy) {
 					break;
 				}
 			}
-			
+
 			otherRoom = this.rooms[ncgx][ncgy];
-			
-			if (otherRoom["connections"].length == 0) { 
-				otherRoom["connections"].push([cgx,cgy]);
-				
+
+			if (otherRoom["connections"].length == 0) {
+				otherRoom["connections"].push([cgx, cgy]);
+
 				this.connectedCells.push([ncgx, ncgy]);
 				cgx = ncgx;
 				cgy = ncgy;
 				found = true;
 			}
-					
-		} while (dirToCheck.length > 0 && found == false)
-		
-	} while (dirToCheck.length > 0)
 
-}
+		} while (dirToCheck.length > 0 && found == false);
 
-ROT.Map.Rogue.prototype._connectUnconnectedRooms = function() {
-	//While there are unconnected rooms, try to connect them to a random connected neighbor 
+	} while (dirToCheck.length > 0);
+
+};
+
+ROT.Map.Rogue.prototype._connectUnconnectedRooms = function () {
+	//While there are unconnected rooms, try to connect them to a random connected neighbor
 	//(if a room has no connected neighbors yet, just keep cycling, you'll fill out to it eventually).
 	var cw = this._options.cellWidth;
 	var ch = this._options.cellHeight;
-	
-	var randomConnectedCell;
+
 	this.connectedCells = this.connectedCells.randomize();
 	var room;
 	var otherRoom;
 	var validRoom;
-	
+
 	for (var i = 0; i < this._options.cellWidth; i++) {
 		for (var j = 0; j < this._options.cellHeight; j++)  {
-				
+
 			room = this.rooms[i][j];
-			
+
 			if (room["connections"].length == 0) {
-				var directions = [0,2,4,6];
+				var directions = [0, 2, 4, 6];
 				directions = directions.randomize();
-				
-				var validRoom = false;
-				
+
+				validRoom = false;
+
 				do {
-					
+
 					var dirIdx = directions.pop();
 					var newI = i + ROT.DIRS[8][dirIdx][0];
 					var newJ = j + ROT.DIRS[8][dirIdx][1];
-					
-					if (newI < 0 || newI >= cw || 
-					newJ < 0 || newJ >= ch) {
-						continue;
-					}
-					
+
+					if (newI < 0 || newI >= cw || newJ < 0 || newJ >= ch) { continue; }
+
 					otherRoom = this.rooms[newI][newJ];
-					
+
 					validRoom = true;
-					
-					if (otherRoom["connections"].length == 0) {
-						break;
-					}
-					
+
+					if (otherRoom["connections"].length == 0) { break; }
+
 					for (var k = 0; k < otherRoom["connections"].length; k++) {
-						if(otherRoom["connections"][k][0] == i && 
-						otherRoom["connections"][k][1] == j) {
+						if (otherRoom["connections"][k][0] == i && otherRoom["connections"][k][1] == j) {
 							validRoom = false;
 							break;
 						}
 					}
-					
-					if (validRoom) break;
-					
-				} while (directions.length)
-				
-				if(validRoom) { 
-					room["connections"].push( [otherRoom["cellx"], otherRoom["celly"]] );  
+
+					if (validRoom) { break; }
+
+				} while (directions.length);
+
+				if (validRoom) {
+					room["connections"].push([otherRoom["cellx"], otherRoom["celly"]]);
 				} else {
 					console.log("-- Unable to connect room.");
 				}
 			}
 		}
 	}
-}
+};
 
-ROT.Map.Rogue.prototype._createRandomRoomConnections = function(connections) {
-	// Empty for now. 
-}
+ROT.Map.Rogue.prototype._createRandomRoomConnections = function (connections) {
+	// Empty for now.
+};
 
 
-ROT.Map.Rogue.prototype._createRooms = function() {
-	// Create Rooms 
-	
+ROT.Map.Rogue.prototype._createRooms = function () {
+	// Create Rooms
+
 	var w = this._width;
 	var h = this._height;
-	
+
 	var cw = this._options.cellWidth;
 	var ch = this._options.cellHeight;
-	
+
 	var cwp = Math.floor(this._width / cw);
 	var chp = Math.floor(this._height / ch);
-	
+
 	var roomw;
 	var roomh;
 	var roomWidth = this._options["roomWidth"];
 	var roomHeight = this._options["roomHeight"];
 	var sx;
 	var sy;
-	var tx;
-	var ty;
 	var otherRoom;
-	
+
 	for (var i = 0; i < cw; i++) {
 		for (var j = 0; j < ch; j++) {
 			sx = cwp * i;
 			sy = chp * j;
-			
-			if (sx == 0) sx = 1;
-			if (sy == 0) sy = 1;
-			
+
+			if (sx == 0) { sx = 1; }
+			if (sy == 0) { sy = 1; }
+
 			roomw = ROT.RNG.getUniformInt(roomWidth[0], roomWidth[1]);
 			roomh = ROT.RNG.getUniformInt(roomHeight[0], roomHeight[1]);
-			
+
 			if (j > 0) {
 				otherRoom = this.rooms[i][j-1];
 				while (sy - (otherRoom["y"] + otherRoom["height"] ) < 3) {
 					sy++;
 				}
 			}
-			
+
 			if (i > 0) {
 				otherRoom = this.rooms[i-1][j];
 				while(sx - (otherRoom["x"] + otherRoom["width"]) < 3) {
 					sx++;
 				}
 			}
-			
+
 			var sxOffset = Math.round(ROT.RNG.getUniformInt(0, cwp-roomw)/2);
 			var syOffset = Math.round(ROT.RNG.getUniformInt(0, chp-roomh)/2);
-			
+
 			while (sx + sxOffset + roomw >= w) {
 				if(sxOffset) {
 					sxOffset--;
 				} else {
-					roomw--; 
+					roomw--;
 				}
 			}
-			
-			while (sy + syOffset + roomh >= h) { 
+
+			while (sy + syOffset + roomh >= h) {
 				if(syOffset) {
 					syOffset--;
 				} else {
-					roomh--; 
+					roomh--;
 				}
 			}
-			
+
 			sx = sx + sxOffset;
 			sy = sy + syOffset;
-			
+
 			this.rooms[i][j]["x"] = sx;
 			this.rooms[i][j]["y"] = sy;
 			this.rooms[i][j]["width"] = roomw;
-			this.rooms[i][j]["height"] = roomh;  
-			
+			this.rooms[i][j]["height"] = roomh;
+
 			for (var ii = sx; ii < sx + roomw; ii++) {
 				for (var jj = sy; jj < sy + roomh; jj++) {
 					this.map[ii][jj] = 0;
 				}
-			}  
+			}
 		}
 	}
-}
+};
 
-ROT.Map.Rogue.prototype._getWallPosition = function(aRoom, aDirection) {
+ROT.Map.Rogue.prototype._getWallPosition = function (aRoom, aDirection) {
 	var rx;
 	var ry;
 	var door;
-	
+
 	if (aDirection == 1 || aDirection == 3) {
 		rx = ROT.RNG.getUniformInt(aRoom["x"] + 1, aRoom["x"] + aRoom["width"] - 2);
 		if (aDirection == 1) {
@@ -306,9 +292,9 @@ ROT.Map.Rogue.prototype._getWallPosition = function(aRoom, aDirection) {
 			ry = aRoom["y"] + aRoom["height"] + 1;
 			door = ry -1;
 		}
-		
-		this.map[rx][door] = 0; // i'm not setting a specific 'door' tile value right now, just empty space. 
-		
+
+		this.map[rx][door] = 0; // i'm not setting a specific 'door' tile value right now, just empty space.
+
 	} else if (aDirection == 2 || aDirection == 4) {
 		ry = ROT.RNG.getUniformInt(aRoom["y"] + 1, aRoom["y"] + aRoom["height"] - 2);
 		if(aDirection == 2) {
@@ -318,41 +304,41 @@ ROT.Map.Rogue.prototype._getWallPosition = function(aRoom, aDirection) {
 			rx = aRoom["x"] - 2;
 			door = rx + 1;
 		}
-		
-		this.map[door][ry] = 0; // i'm not setting a specific 'door' tile value right now, just empty space. 
-		
+
+		this.map[door][ry] = 0; // i'm not setting a specific 'door' tile value right now, just empty space.
+
 	}
 	return [rx, ry];
-}
+};
 
 /***
 * @param startPosition a 2 element array
 * @param endPosition a 2 element array
 */
-ROT.Map.Rogue.prototype._drawCorridore = function (startPosition, endPosition) {
+ROT.Map.Rogue.prototype._drawCorridor = function (startPosition, endPosition) {
 	var xOffset = endPosition[0] - startPosition[0];
 	var yOffset = endPosition[1] - startPosition[1];
-	
+
 	var xpos = startPosition[0];
 	var ypos = startPosition[1];
-	
+
 	var tempDist;
 	var xDir;
 	var yDir;
-	
-	var move; // 2 element array, element 0 is the direction, element 1 is the total value to move. 
+
+	var move; // 2 element array, element 0 is the direction, element 1 is the total value to move.
 	var moves = []; // a list of 2 element arrays
-	
+
 	var xAbs = Math.abs(xOffset);
 	var yAbs = Math.abs(yOffset);
-	
+
 	var percent = ROT.RNG.getUniform(); // used to split the move at different places along the long axis
 	var firstHalf = percent;
 	var secondHalf = 1 - percent;
-	
+
 	xDir = xOffset > 0 ? 2 : 6;
 	yDir = yOffset > 0 ? 4 : 0;
-	
+
 	if (xAbs < yAbs) {
 		// move firstHalf of the y offset
 		tempDist = Math.ceil(yAbs * firstHalf);
@@ -370,11 +356,11 @@ ROT.Map.Rogue.prototype._drawCorridore = function (startPosition, endPosition) {
 		moves.push([yDir, yAbs]);
 		// move secondHalf of the x offset.
 		tempDist = Math.floor(xAbs * secondHalf);
-		moves.push([xDir, tempDist]);  
+		moves.push([xDir, tempDist]);
 	}
-	
+
 	this.map[xpos][ypos] = 0;
-	
+
 	while (moves.length > 0) {
 		move = moves.pop();
 		while (move[1] > 0) {
@@ -384,11 +370,11 @@ ROT.Map.Rogue.prototype._drawCorridore = function (startPosition, endPosition) {
 			move[1] = move[1] - 1;
 		}
 	}
-}
+};
 
 ROT.Map.Rogue.prototype._createCorridors = function () {
 	// Draw Corridors between connected rooms
-	
+
 	var cw = this._options.cellWidth;
 	var ch = this._options.cellHeight;
 	var room;
@@ -396,23 +382,23 @@ ROT.Map.Rogue.prototype._createCorridors = function () {
 	var otherRoom;
 	var wall;
 	var otherWall;
-	
+
 	for (var i = 0; i < cw; i++) {
 		for (var j = 0; j < ch; j++) {
 			room = this.rooms[i][j];
-			
+
 			for (var k = 0; k < room["connections"].length; k++) {
-					
-				connection = room["connections"][k]; 
-				
+
+				connection = room["connections"][k];
+
 				otherRoom = this.rooms[connection[0]][connection[1]];
-				
+
 				// figure out what wall our corridor will start one.
-				// figure out what wall our corridor will end on. 
-				if (otherRoom["cellx"] > room["cellx"] ) {
+				// figure out what wall our corridor will end on.
+				if (otherRoom["cellx"] > room["cellx"]) {
 					wall = 2;
 					otherWall = 4;
-				} else if (otherRoom["cellx"] < room["cellx"] ) {
+				} else if (otherRoom["cellx"] < room["cellx"]) {
 					wall = 4;
 					otherWall = 2;
 				} else if(otherRoom["celly"] > room["celly"]) {
@@ -422,9 +408,9 @@ ROT.Map.Rogue.prototype._createCorridors = function () {
 					wall = 1;
 					otherWall = 3;
 				}
-				
-				this._drawCorridore(this._getWallPosition(room, wall), this._getWallPosition(otherRoom, otherWall));
+
+				this._drawCorridor(this._getWallPosition(room, wall), this._getWallPosition(otherRoom, otherWall));
 			}
 		}
 	}
-}
+};


### PR DESCRIPTION
Nothing specifically addressed in #62, though it looks like there were additional unused variables that were initialized but never used.

Summary:
Removed unused variables.
Fixed spelling error in "_drawCorridore" method.
Made code style more internally consistent.