### PR TITLE
Functionally accumulating values

### DIFF
--- a/src/fov/discrete-shadowcasting.js
+++ b/src/fov/discrete-shadowcasting.js
@@ -10,19 +10,19 @@ ROT.FOV.DiscreteShadowcasting.extend(ROT.FOV);
 /**
  * @see ROT.FOV#compute
  */
-ROT.FOV.DiscreteShadowcasting.prototype.compute = function(x, y, R, callback) {
+ROT.FOV.DiscreteShadowcasting.prototype.compute = function(x, y, R, callback, initialValue) {
 	var center = this._coords;
 	var map = this._map;
 
 	/* this place is always visible */
-	callback(x, y, 0, 1);
+	var accumulator = callback(x, y, 0, 1, initalValue);
 
 	/* standing in a dark place. FIXME is this a good idea?  */
-	if (!this._lightPasses(x, y)) { return; }
-	
+	if (!this._lightPasses(x, y)) { return accumulator; }
+
 	/* start and end angles */
 	var DATA = [];
-	
+
 	var A, B, cx, cy, blocks;
 
 	/* analyze surrounding cells in concentric rings, starting from the center */
@@ -35,14 +35,17 @@ ROT.FOV.DiscreteShadowcasting.prototype.compute = function(x, y, R, callback) {
 			cy = neighbors[i][1];
 			A = angle * (i - 0.5);
 			B = A + angle;
-			
+
 			blocks = !this._lightPasses(cx, cy);
-			if (this._visibleCoords(Math.floor(A), Math.ceil(B), blocks, DATA)) { callback(cx, cy, r, 1); }
-			
-			if (DATA.length == 2 && DATA[0] == 0 && DATA[1] == 360) { return; } /* cutoff? */
+			if (this._visibleCoords(Math.floor(A), Math.ceil(B), blocks, DATA)) {
+				accumulator = callback(cx, cy, r, 1, accumulator);
+			}
+
+			if (DATA.length == 2 && DATA[0] == 0 && DATA[1] == 360) { return accumulator; } /* cutoff? */
 
 		} /* for all cells in this ring */
 	} /* for all rings */
+	return accumulator;
 }
 
 /**
@@ -52,38 +55,38 @@ ROT.FOV.DiscreteShadowcasting.prototype.compute = function(x, y, R, callback) {
  * @param {int[][]} DATA shadowed angle pairs
  */
 ROT.FOV.DiscreteShadowcasting.prototype._visibleCoords = function(A, B, blocks, DATA) {
-	if (A < 0) { 
+	if (A < 0) {
 		var v1 = arguments.callee(0, B, blocks, DATA);
 		var v2 = arguments.callee(360+A, 360, blocks, DATA);
 		return v1 || v2;
 	}
-	
+
 	var index = 0;
 	while (index < DATA.length && DATA[index] < A) { index++; }
-	
+
 	if (index == DATA.length) { /* completely new shadow */
-		if (blocks) { DATA.push(A, B); } 
+		if (blocks) { DATA.push(A, B); }
 		return true;
 	}
-	
+
 	var count = 0;
-	
+
 	if (index % 2) { /* this shadow starts in an existing shadow, or within its ending boundary */
 		while (index < DATA.length && DATA[index] < B) {
 			index++;
 			count++;
 		}
-		
+
 		if (count == 0) { return false; }
-		
-		if (blocks) { 
+
+		if (blocks) {
 			if (count % 2) {
 				DATA.splice(index-count, count, B);
 			} else {
 				DATA.splice(index-count, count);
 			}
 		}
-		
+
 		return true;
 
 	} else { /* this shadow starts outside an existing shadow, or within a starting boundary */
@@ -91,18 +94,18 @@ ROT.FOV.DiscreteShadowcasting.prototype._visibleCoords = function(A, B, blocks, 
 			index++;
 			count++;
 		}
-		
+
 		/* visible when outside an existing shadow, or when overlapping */
 		if (A == DATA[index-count] && count == 1) { return false; }
-		
-		if (blocks) { 
+
+		if (blocks) {
 			if (count % 2) {
 				DATA.splice(index-count, count, A);
 			} else {
 				DATA.splice(index-count, count, A, B);
 			}
 		}
-			
+
 		return true;
 	}
 }

--- a/src/fov/fov.js
+++ b/src/fov/fov.js
@@ -19,7 +19,7 @@ ROT.FOV = function(lightPassesCallback, options) {
  * @param {int} R Maximum visibility radius
  * @param {function} callback
  */
-ROT.FOV.prototype.compute = function(x, y, R, callback) {}
+ROT.FOV.prototype.compute = function(x, y, R, callback, initialValue) {}
 
 /**
  * Return all neighbors in a concentric ring

--- a/src/path/astar.js
+++ b/src/path/astar.js
@@ -17,7 +17,7 @@ ROT.Path.AStar.extend(ROT.Path);
  * Compute a path from a given point
  * @see ROT.Path#compute
  */
-ROT.Path.AStar.prototype.compute = function(fromX, fromY, callback) {
+ROT.Path.AStar.prototype.compute = function(fromX, fromY, callback, initialValue) {
 	this._todo = [];
 	this._done = {};
 	this._fromX = fromX;
@@ -35,17 +35,19 @@ ROT.Path.AStar.prototype.compute = function(fromX, fromY, callback) {
 			var y = neighbor[1];
 			var id = x+","+y;
 			if (id in this._done) { continue; }
-			this._add(x, y, item); 
+			this._add(x, y, item);
 		}
 	}
-	
+
 	var item = this._done[fromX+","+fromY];
-	if (!item) { return; }
-	
+	if (!item) { return initialValue; }
+
+	var accumulator = initialValue;
 	while (item) {
-		callback(item.x, item.y);
+		accumulator = callback(item.x, item.y, accumulator);
 		item = item.prev;
 	}
+	return accumulator;
 }
 
 ROT.Path.AStar.prototype._add = function(x, y, prev) {
@@ -58,9 +60,9 @@ ROT.Path.AStar.prototype._add = function(x, y, prev) {
 		h: h
 	}
 	this._done[x+","+y] = obj;
-	
+
 	/* insert into priority queue */
-	
+
 	var f = obj.g + obj.h;
 	for (var i=0;i<this._todo.length;i++) {
 		var item = this._todo[i];
@@ -70,7 +72,7 @@ ROT.Path.AStar.prototype._add = function(x, y, prev) {
 			return;
 		}
 	}
-	
+
 	this._todo.push(obj);
 }
 
@@ -86,7 +88,7 @@ ROT.Path.AStar.prototype._distance = function(x, y) {
 			return dy + Math.max(0, (dx-dy)/2);
 		break;
 
-		case 8: 
+		case 8:
 			return Math.max(Math.abs(x-this._fromX), Math.abs(y-this._fromY));
 		break;
 	}

--- a/src/path/dijkstra.js
+++ b/src/path/dijkstra.js
@@ -16,16 +16,18 @@ ROT.Path.Dijkstra.extend(ROT.Path);
  * Compute a path from a given point
  * @see ROT.Path#compute
  */
-ROT.Path.Dijkstra.prototype.compute = function(fromX, fromY, callback) {
+ROT.Path.Dijkstra.prototype.compute = function(fromX, fromY, callback, initialValue) {
 	var key = fromX+","+fromY;
 	if (!(key in this._computed)) { this._compute(fromX, fromY); }
-	if (!(key in this._computed)) { return; }
-	
+	if (!(key in this._computed)) { return initialValue; }
+
 	var item = this._computed[key];
+	var accumulator = initialValue
 	while (item) {
-		callback(item.x, item.y);
+		accumulator = callback(item.x, item.y, accumulator);
 		item = item.prev;
 	}
+	return accumulator;
 }
 
 /**
@@ -35,16 +37,16 @@ ROT.Path.Dijkstra.prototype._compute = function(fromX, fromY) {
 	while (this._todo.length) {
 		var item = this._todo.shift();
 		if (item.x == fromX && item.y == fromY) { return; }
-		
+
 		var neighbors = this._getNeighbors(item.x, item.y);
-		
+
 		for (var i=0;i<neighbors.length;i++) {
 			var neighbor = neighbors[i];
 			var x = neighbor[0];
 			var y = neighbor[1];
 			var id = x+","+y;
-			if (id in this._computed) { continue; } /* already done */	
-			this._add(x, y, item); 
+			if (id in this._computed) { continue; } /* already done */
+			this._add(x, y, item);
 		}
 	}
 }

--- a/src/path/path.js
+++ b/src/path/path.js
@@ -38,7 +38,7 @@ ROT.Path = function(toX, toY, passableCallback, options) {
  * @param {int} fromY
  * @param {function} callback Will be called for every path item with arguments "x" and "y"
  */
-ROT.Path.prototype.compute = function(fromX, fromY, callback) {
+ROT.Path.prototype.compute = function(fromX, fromY, callback, initialValue) {
 }
 
 ROT.Path.prototype._getNeighbors = function(cx, cy) {
@@ -47,10 +47,10 @@ ROT.Path.prototype._getNeighbors = function(cx, cy) {
 		var dir = this._dirs[i];
 		var x = cx + dir[0];
 		var y = cy + dir[1];
-		
+
 		if (!this._passableCallback(x, y)) { continue; }
 		result.push([x, y]);
 	}
-	
+
 	return result;
 }


### PR DESCRIPTION
One problem I've been having in writing PureScript bindings for rot.js is getting data out of the functions that rely on callbacks. Functions like FOV.compute require the user to pass in a callback that is obligated to accumulate mutable state. While this is possible in PureScript, it's inelegant and difficult to compose.

This pull request allows the user to instead accumulate a value in a functional manner. Functions like FOV.compute now take an additional argument, `initialValue` that is passed through to the
callback as the last argument, which then returns the accumulator which is again passed to the callback, and so on. Finally, FOV.compute returns the accumulator when finished. Because these
have been tacked on to the parameters list, the change should be backwards compatible. (`undefined` will be accumulated.)

Optimally, you'd be able to do this for the map and lighting interfaces as well. Unfortunately, they already return a value. The only value they return, however, is `this`. I'd personally change them to return an accumulator as well, but this might break existing code.

Anyway, I understand this is a weird request and will understand if you don't like it.

PS. Sorry about deleting the trailing whitespace. I keep forgetting to turn of that "feature" of Atom.