### PR TITLE
Allow Speed scheduler to accept an initial time

### DIFF
--- a/src/eventqueue.js
+++ b/src/eventqueue.js
@@ -57,6 +57,17 @@ ROT.EventQueue.prototype.get = function() {
 }
 
 /**
+ * Get the time associated with the given event
+ * @param {?} event
+ * @returns {number} time
+ */
+ROT.EventQueue.prototype.getEventTime = function(event) {
+	var index = this._events.indexOf(event);
+	if (index == -1) { return undefined }
+	return this._eventTimes[index];
+}
+
+/**
  * Remove an event from the queue
  * @param {?} event
  * @returns {bool} success?

--- a/src/scheduler/scheduler-speed.js
+++ b/src/scheduler/scheduler-speed.js
@@ -10,10 +10,11 @@ ROT.Scheduler.Speed.extend(ROT.Scheduler);
 /**
  * @param {object} item anything with "getSpeed" method
  * @param {bool} repeat
+ * @param {number} [time=1/item.getSpeed()]
  * @see ROT.Scheduler#add
  */
-ROT.Scheduler.Speed.prototype.add = function(item, repeat) {
-	this._queue.add(item, 1/item.getSpeed());
+ROT.Scheduler.Speed.prototype.add = function(item, repeat, time) {
+	this._queue.add(item, time !== undefined ? time : 1/item.getSpeed());
 	return ROT.Scheduler.prototype.add.call(this, item, repeat);
 }
 

--- a/src/scheduler/scheduler.js
+++ b/src/scheduler/scheduler.js
@@ -24,6 +24,15 @@ ROT.Scheduler.prototype.add = function(item, repeat) {
 }
 
 /**
+ * Get the time the given item is scheduled for
+ * @param {?} item
+ * @returns {number} time
+ */
+ROT.Scheduler.prototype.getTimeOf = function(item) {
+	return this._queue.getEventTime(item);
+}
+
+/**
  * Clear all items
  */
 ROT.Scheduler.prototype.clear = function() {

--- a/tests/spec/eventqueue.js
+++ b/tests/spec/eventqueue.js
@@ -17,6 +17,25 @@ describe("EventQueue", function() {
 		expect(q.get()).toEqual(null);
 	});
 
+	it("should look up time of events", function() {
+		var q = new ROT.EventQueue();
+		q.add(123, 187);
+		q.add(456, 42);
+		expect(q.getEventTime(123)).toEqual(187);
+		expect(q.getEventTime(456)).toEqual(42);
+	});
+
+	it("should look up correct times after events removed", function() {
+		var q = new ROT.EventQueue();
+		q.add(123, 187);
+		q.add(456, 42);
+		q.add(789, 411);
+                q.get();
+		expect(q.getEventTime(456)).toBeUndefined();
+		expect(q.getEventTime(123)).toEqual(187 - 42);
+		expect(q.getEventTime(789)).toEqual(411 - 42);
+	});
+
 	it("should remove events", function() {
 		var q = new ROT.EventQueue();
 		q.add(123, 0);

--- a/tests/spec/scheduler.js
+++ b/tests/spec/scheduler.js
@@ -89,6 +89,23 @@ describe("Scheduler", function() {
 			for (var i=0;i<7;i++) { result.push(S.next()); }
 			expect(result).toSchedule([A200, A100a, A200, A200, A50, A100a, A200]);
 		});
+
+		it("should schedule with initial offsets", function() {
+			S.add(A50, true, 1/300);
+			S.add(A100a, true, 0);
+			S.add(A200, true);
+			var result = [];
+			for (var i=0;i<9;i++) { result.push(S.next()); }
+			expect(result).toSchedule([A100a, A50, A200, A100a, A200, A200, A100a, A200, A50]);
+		});
+
+		it("should look up the time of an event", function() {
+			S.add(A100a, true);
+			S.add(A50, true, 1/200);
+			expect(S.getTimeOf(A50)).toEqual(1/200);
+			expect(S.getTimeOf(A100a)).toEqual(1/100);
+		});
+
 	});
 
 	describe("Action", function() {


### PR DESCRIPTION
Adds an additional optional time argument to Scheduler.Speed.add(), which
defines an initial time to schedule the item. If the item is repeated then
subsequent scheduling will use 1/item.getSpeed() as before.

Also exposes an item's time through a Scheduler.getTimeOf(item) method. In
combination, these two changes allow clients to completely recreate the
state of the speed scheduler at a given point, useful when saving and
restoring a game state.