### PR TITLE
Fix most non-ASCII characters treated as fullwidth

### DIFF
--- a/src/display/display.js
+++ b/src/display/display.js
@@ -200,7 +200,7 @@ ROT.Display.prototype.drawText = function(x, y, text, maxWidth) {
 					var cc = token.value.charCodeAt(i);
 					var c = token.value.charAt(i);
 					// Assign to `true` when the current char is full-width.
-					isFullWidth = (cc > 0xff && cc < 0xff61) || (cc > 0xffdc && cc < 0xffe8) && cc > 0xffee;
+					isFullWidth = (cc > 0xff00 && cc < 0xff61) || (cc > 0xffdc && cc < 0xffe8) || cc > 0xffee;
 					// Current char is space, whatever full-width or half-width both are OK.
 					isSpace = (c.charCodeAt(0) == 0x20 || c.charCodeAt(0) == 0x3000);
 					// The previous char is full-width and


### PR DESCRIPTION
When the rendering engine decides that a character is full-width, it skips a space, leaving it untouched, and continues in the next space. This looks _really_ bad when the character is not, in fact, full-width. (I don't know if it looks good when the character _is_ full-width.) This patch just fixes the detection of full-width characters in the Basic Multilingual Plane. (That last `cc > 0xffee` is also wrong, but didn't seem worth fixing.)

There's probably still issues with this line, as this change also squishes Chinese characters together for example... but Chinese characters didn't fit vertically into the cell either in my quick test. Still, additional ranges for CJK ideographs probably need to be added.