### PR TITLE
Fix neighbor check for non-square ROT.Map.Cellular

### DIFF
--- a/src/map/cellular.js
+++ b/src/map/cellular.js
@@ -105,7 +105,7 @@ ROT.Map.Cellular.prototype._getNeighbors = function(cx, cy) {
 		var x = cx + dir[0];
 		var y = cy + dir[1];
 
-		if (x < 0 || x >= this._width || y < 0 || y >= this._width) { continue; }
+		if (x < 0 || x >= this._width || y < 0 || y >= this._height) { continue; }
 		result += (this._map[x][y] == 1 ? 1 : 0);
 	}
 


### PR DESCRIPTION
This was causing the lower part of the map to always be 100% blocked.