### PR TITLE
Modifying built-in Array prototype potentially causes collisions

### DIFF
--- a/src/js/array.js
+++ b/src/js/array.js
@@ -1,19 +1,19 @@
 /**
  * @returns {any} Randomly picked item, null when length=0
  */
-Array.prototype.random = Array.prototype.random || function() {
-	if (!this.length) { return null; }
-	return this[Math.floor(ROT.RNG.getUniform() * this.length)];
+var getRandomItem = function(arr) {
+	if (!arr.length) { return null; }
+	return arr[Math.floor(ROT.RNG.getUniform() * arr.length)];
 };
 
 /**
  * @returns {array} New array with randomized items
  */
-Array.prototype.randomize = Array.prototype.randomize || function() {
+var getRandomizedArray = function(arr) {
   var result = [];
-  var clone = this.slice();
+  var clone = arr.slice();
   while (clone.length) {
-    var index = clone.indexOf(clone.random());
+    var index = clone.indexOf(getRandomItem(clone));
     result.push(clone.splice(index, 1)[0]);
   }
   return result;

--- a/src/map/digger.js
+++ b/src/map/digger.js
@@ -146,7 +146,7 @@ ROT.Map.Digger.prototype._findWall = function() {
 	var arr = (prio2.length ? prio2 : prio1);
 	if (!arr.length) { return null; } /* no walls :/ */
 	
-	var id = arr.sort().random(); // sort to make the order deterministic
+	var id = getRandomItem(arr.sort()); // sort to make the order deterministic
 	delete this._walls[id];
 
 	return id;

--- a/src/map/dividedmaze.js
+++ b/src/map/dividedmaze.js
@@ -61,8 +61,8 @@ ROT.Map.DividedMaze.prototype._partitionRoom = function(room) {
 
 	if (!availX.length || !availY.length) { return; }
 
-	var x = availX.random();
-	var y = availY.random();
+	var x = getRandomItem(availX);
+	var y = getRandomItem(availY);
 	
 	this._map[x][y] = 1;
 	
@@ -92,12 +92,12 @@ ROT.Map.DividedMaze.prototype._partitionRoom = function(room) {
 		w.push([x, j]); 
 	}
 		
-	var solid = walls.random();
+	var solid = getRandomItem(walls);
 	for (var i=0;i<walls.length;i++) {
 		var w = walls[i];
 		if (w == solid) { continue; }
 		
-		var hole = w.random();
+		var hole = getRandomItem(w);
 		this._map[hole[0]][hole[1]] = 0;
 	}
 

--- a/src/map/rogue.js
+++ b/src/map/rogue.js
@@ -97,7 +97,7 @@ ROT.Map.Rogue.prototype._connectRooms = function () {
 
 		//var dirToCheck = [0, 1, 2, 3, 4, 5, 6, 7];
 		var dirToCheck = [0, 2, 4, 6];
-		dirToCheck = dirToCheck.randomize();
+		dirToCheck = getRandomizedArray(dirToCheck);
 
 		do {
 			found = false;
@@ -141,7 +141,7 @@ ROT.Map.Rogue.prototype._connectUnconnectedRooms = function () {
 	var cw = this._options.cellWidth;
 	var ch = this._options.cellHeight;
 
-	this.connectedCells = this.connectedCells.randomize();
+	this.connectedCells = getRandomizedArray(this.connectedCells);
 	var room;
 	var otherRoom;
 	var validRoom;
@@ -153,7 +153,7 @@ ROT.Map.Rogue.prototype._connectUnconnectedRooms = function () {
 
 			if (room["connections"].length == 0) {
 				var directions = [0, 2, 4, 6];
-				directions = directions.randomize();
+				directions = getRandomizedArray(directions);
 
 				validRoom = false;
 

--- a/src/map/uniform.js
+++ b/src/map/uniform.js
@@ -108,13 +108,13 @@ ROT.Map.Uniform.prototype._generateCorridors = function() {
 			room.create(this._digCallback); 
 		}
 
-		this._unconnected = this._rooms.slice().randomize();
+		this._unconnected = getRandomizedArray(this._rooms.slice());
 		this._connected = [];
 		if (this._unconnected.length) { this._connected.push(this._unconnected.pop()); } /* first one is always connected */
 		
 		while (1) {
 			/* 1. pick random connected room */
-			var connected = this._connected.random();
+			var connected = getRandomItem(this._connected);
 			
 			/* 2. find closest unconnected */
 			var room1 = this._closestRoom(this._unconnected, connected);
@@ -298,7 +298,7 @@ ROT.Map.Uniform.prototype._placeInWall = function(room, dirIndex) {
 	for (var i=avail.length-1; i>=0; i--) {
 		if (!avail[i]) { avail.splice(i, 1); }
 	}
-	return (avail.length ? avail.random() : null);
+	return (avail.length ? getRandomItem(avail) : null);
 };
 
 /**

--- a/src/noise/simplex.js
+++ b/src/noise/simplex.js
@@ -31,7 +31,7 @@ ROT.Noise.Simplex = function(gradients) {
 	var permutations = [];
 	var count = gradients || 256;
 	for (var i=0;i<count;i++) { permutations.push(i); }
-	permutations = permutations.randomize();
+	permutations = getRandomizedArray(permutations);
 
 	this._perms = [];
 	this._indexes = [];


### PR DESCRIPTION
I ran into an issue while using this library whereby another library had also added a .random() function to the built-in Array prototype.  The other implementation did not select a random item but randomized the Array (in-place) breaking various functionality in rot.js.

I have replaced all instances of _Array.random()_ and _Array.randomize()_ with the local functions _getRandomItem(Array)_ and _getRandomizedArray(Array)_, which seems to have fixed the issue.

Generally modifying built-in prototypes is considered bad practice for this reason and a couple of others - there are several other instances of this in the library, but as these were not causing issue for me I have not removed them.