### PR TITLE
Expose TypeScript types for library use

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
         }
       ]
     ]
-  }
+  },
+  "types": "./lib/index.d.ts"
 }


### PR DESCRIPTION
🎉🎉 TypeScript, yay!  🎉🎉

However, the `package.json` doesn't expose the typings, so trying to use them in a project doesn't work. 

This pull request makes a tiny change to `package.json` to tell TypeScript where the types are, so when you import this library into a new project, it Just Works® without `@types/rot-js`.

The `package.json` didn't appear to be in any particular order so it was difficult to guess the best place to put it, so I put it at the bottom.