### PR TITLE
Fix implicit any type for Scheduler.next()/remove()

### DIFF
--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -3,7 +3,7 @@ import EventQueue from "../eventqueue.js";
 export default class Scheduler<T = any> {
 	_queue: EventQueue<T>;
 	_repeat: T[];
-	_current: any;
+	_current: T | null;
 
 	/**
 	 * @class Abstract scheduler
@@ -52,7 +52,7 @@ export default class Scheduler<T = any> {
 	 * @param {?} item
 	 * @returns {bool} successful?
 	 */
-	remove(item: any) {
+	remove(item: T) {
 		let result = this._queue.remove(item);
 
 		let index = this._repeat.indexOf(item);


### PR DESCRIPTION
**Addressed Issues**

`Scheduler<T>` takes a type, but its internal representation of the object tracker (`_current`) was set to `any` instead of `T`. This resulted in `next()` returning `any`, which lost typing and required unnecessary casting when it is called.

This also creates an error that could be caught at compile time, as `next()` can also return null, which is not enforced by the type checker.

Lastly, `remove(thing: any)` lost the compiler-time checking when calling it.

**Fixes**

This fixes `next()` and `remove()` to use the expected `T` so that the type checker catches all of these issues with all of the schedulers.

I didn't run the make process with the PR because I'm unclear if you do that yourself, but I'm happy to push another commit with doc/lib built.

### Example

From the documentation, here's an example of where this was going wrong:

```typescript

interface SpeedyActor {
  number: number
  getSpeed: () => number
}

const scheduler = new Scheduler.Speed<SpeedyActor>()

/* simulate several turns */
const turns = []
for (let i = 0; i < 40; i++) {
    const current = scheduler.next() // without this PR, `current` is `any`
    // `current` can be null, but this isn't type check enforced
    turns.push(current.number) // `current` not type checked during usage either
}

scheduler.remove("bad entry") // should be a typeof SpeedyActor but it will take anything
```

These issues are fixed by the PR.