### PR TITLE
Keep .d.ts doc comments for TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,7 @@
 		"declaration": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "lib",
-		"removeComments": true
+		"outDir": "lib"
 	},
 
 	"files": ["src/index.ts"]


### PR DESCRIPTION
Currently, `tsconfig.json` is configured to remove comments, which results in all of the `.d.ts` files being undocumented. At first, I thought all of these methods weren't documented, but after looking at the code I realized that there's all this good documentation being stripped out.

**Before PR - what's this do?**

<img width="653" alt="screen_shot_2018-11-30_at_6_19_30_am" src="https://user-images.githubusercontent.com/438465/49289281-ee80e180-f468-11e8-99e6-b5c6ec8e71fe.png">

**After PR - documentation!**

<img width="767" alt="screen_shot_2018-11-30_at_6_12_04_am" src="https://user-images.githubusercontent.com/438465/49289299-fe002a80-f468-11e8-91f5-e06689341a59.png">
