### PR TITLE
Strictly type parameter of getWeightedValue

### DIFF
--- a/src/rng.ts
+++ b/src/rng.ts
@@ -105,7 +105,7 @@ class RNG {
 	 * @param data key=whatever, value=weight (relative probability)
 	 * @returns whatever
 	 */
-	getWeightedValue(data: any) {
+	getWeightedValue(data: { [key: string]: number, [key: number]: number }) {
 		let total = 0;
 		
 		for (let id in data) {


### PR DESCRIPTION
Currently, `getWeightedValue` is typed as `data: any`, but it expects the set to have numeric values. This can result in compile-time validity but runtime errors.

**Before PR**
```typescript
RNG.getWeightedValue({ 'monster': 'error!' }) // causes runtime error but compiles fine
```

**After PR**
```typescript
// compile-time error: Type 'string' is not assignable to type 'number'.
RNG.getWeightedValue({ 'monster': 'error!' }) 

// works
RNG.getWeightedValue({ 'monster': 30, 50: 10 }) 
```

If the index signature looks a little odd, here's why: TypeScript expects index signatures to must be literal `string` or `number`, but doesn't allow you to have a `string | number` union. The type in this PR is a signature overload, so TS knows that if the key is a string or a number, the value must be a number, which covers all of the valid cases in TS/JS.