### PR TITLE
drawText: cjk bug fixed

### DIFF
--- a/src/display/display.ts
+++ b/src/display/display.ts
@@ -200,6 +200,17 @@ export default class Display {
 					for (let i=0;i<token.value.length;i++) {
 						let cc = token.value.charCodeAt(i);
 						let c = token.value.charAt(i);
+						if (this._options.layout === "term") {
+							let cch = cc >> 8;
+							let isCJK = cch === 0x11 || (cch >= 0x2e && cch <= 0x9f) || (cch >= 0xac && cch <= 0xd7) || (cc >= 0xA960 && cc <= 0xA97F);
+							if (isCJK) {
+								this.draw(cx + 0, cy, c, fg, bg);
+								this.draw(cx + 1, cy, "\t", fg, bg);
+								cx += 2;
+								continue;
+							}
+						}
+
 						// Assign to `true` when the current char is full-width.
 						isFullWidth = (cc > 0xff00 && cc < 0xff61) || (cc > 0xffdc && cc < 0xffe8) || cc > 0xffee;
 						// Current char is space, whatever full-width or half-width both are OK.

--- a/src/display/term.ts
+++ b/src/display/term.ts
@@ -83,9 +83,11 @@ export default class Term extends Backend {
 			this._lastColor = newColor;
 		}
 
-		// write the provided symbol to the display
-		let chars = ([] as string[]).concat(ch);
-		process.stdout.write(chars[0]);
+		if (ch != '\t') {
+			// write the provided symbol to the display
+			let chars = ([] as string[]).concat(ch);
+			process.stdout.write(chars[0]);
+		}
 
 		// update our position, given that we wrote a character
 		this._cursor[0]++;


### PR DESCRIPTION
cjk characters are full-width characters but rot.js can't draw them on display layout("term")

old encoded cjk characters have 2 codes and move the cursor 2 spaces. 
```
Ah
아
あ
啊
```
unicode cjk character have 1~3 codes and move the cursor 2 spaces.
```
아
0xC544 (unicode)
0xEC, 0x95, 0x84 (utf-8)
```
we can only choose whole cjk character 
and can't choose separated space on terminal(with cjk encoding).

but rot.js can draw some codes in the unknown separated spaces. i think it makes the cjk bug. 
if we avoid the bug, first space is placed unicode character and second space should be empty (and deleted if there is something already.)

i wanted to used the null or empty character for deleting 
but have choosed the other character ('\t') because null or empty character is already used. 

if you give me a better character or other solution, i'll apply it : )

thanks 