### PR TITLE
Fixes a few broken links

### DIFF
--- a/manual/pages/fov.html
+++ b/manual/pages/fov.html
@@ -14,7 +14,7 @@ the meaning is that "the place at [x,y] is visible with a distance of r". The la
 
 <p>Currently there are these FOV algorithms available: </p>
 <ol>
-	<li><a href="http://www.roguebasin.roguelikedevelopment.org/index.php?title=Precise_Shadowcasting_in_JavaScript">Precise Shadowcasting</a></li>
+	<li><a href="http://roguebasin.com/index.php/Precise_Shadowcasting_in_JavaScript">Precise Shadowcasting</a></li>
 	<li><a href="http://www.roguebasin.com/index.php?title=FOV_using_recursive_shadowcasting">Recursive Shadowcasting</a></li>
 </ol>
 

--- a/manual/pages/map/cellular.html
+++ b/manual/pages/map/cellular.html
@@ -19,7 +19,7 @@ because it offers richer features and is more configurable.</p>
 
 <p>It is possible (and desirable) to call the <code>create</code> method repeatedly: every call will create a new generation. There is no need to specify a callback, 
 if you only want to advance into next generation, without actually retrieving the current map data. By default, the <em>born</em> and <em>survive</em> options 
-are set according to this <a href="http://www.roguebasin.roguelikedevelopment.org/index.php/Cellular_Automata_Method_for_Generating_Random_Cave-Like_Levels">Roguebasin article</a>.</p>
+are set according to this <a href="http://roguebasin.com/index.php/Cellular_Automata_Method_for_Generating_Random_Cave-Like_Levels">Roguebasin article</a>.</p>
 
 <p><code>ROT.Map.Cellular</code> uses the following callback values:</p>
 <ul>

--- a/manual/pages/map/dungeon.html
+++ b/manual/pages/map/dungeon.html
@@ -29,7 +29,7 @@ for (var i=0; i&lt;rooms.length; i++) {
 <h3>Digger</h3>
 
 <p>Random dungeon generator using human-like digging patterns; based on Mike Anderson's ideas from the "Tyrant" algo, mentioned at 
-<a href="http://www.roguebasin.roguelikedevelopment.org/index.php?title=Dungeon-Building_Algorithm">Roguebasin</a>. 
+<a href="http://roguebasin.com/index.php/Dungeon-Building_Algorithm">Roguebasin</a>. 
 Third constructor argument is a configuration object; allowed options:</p>
 <ul>
 	<li><code>roomWidth</code> &ndash; [min, max] room size</li>

--- a/manual/pages/map/maze.html
+++ b/manual/pages/map/maze.html
@@ -24,7 +24,7 @@ for (var i=0; i&lt;4; i++) {
 
 <h3>Icey's Maze</h3>
 
-<p>Cool mazes with a configurable regularity can be created using this <a href="http://www.roguebasin.roguelikedevelopment.org/index.php?title=Simple_maze#Maze_Generator_in_Visual_Basic_6">algorithm</a>, 
+<p>Cool mazes with a configurable regularity can be created using this <a href="http://roguebasin.com/index.php/Simple_maze#Maze_Generator_in_Visual_Basic_6">algorithm</a>, 
 taken from a Rogue Basin wiki. Regularity is an integer value, specified as a third argument; 0 = most random.</p>
 
 <div class="example">

--- a/manual/pages/stringgenerator.html
+++ b/manual/pages/stringgenerator.html
@@ -2,7 +2,7 @@
 
 <p><code>ROT.StringGenerator</code> is an implementation of a high order Markov process. This machine learning technique needs to be <em>trained</em> first (with a set of typical strings); after training, it generates strings similar to those used as a training set.</p>
 
-<p>Read more about the implementation (Dirichlet prior, simplified Katz back-off) in this <a href="http://www.roguebasin.roguelikedevelopment.org/index.php?title=Names_from_a_high_order_Markov_Process_and_a_simplified_Katz_back-off_scheme">RogueBasin article</a>. The constructor accepts an optional configuration object with the following keys:</p>
+<p>Read more about the implementation (Dirichlet prior, simplified Katz back-off) in this <a href="http://roguebasin.com/index.php/Names_from_a_high_order_Markov_Process_and_a_simplified_Katz_back-off_scheme">RogueBasin article</a>. The constructor accepts an optional configuration object with the following keys:</p>
 
 <ul>
 	<li><code>words</code> &ndash; use word mode? (default: false, use letters instead)</li>

--- a/src/map/digger.ts
+++ b/src/map/digger.ts
@@ -22,7 +22,7 @@ interface Options {
 /**
  * Random dungeon generator using human-like digging patterns.
  * Heavily based on Mike Anderson's ideas from the "Tyrant" algo, mentioned at 
- * http://www.roguebasin.roguelikedevelopment.org/index.php?title=Dungeon-Building_Algorithm.
+ * http://roguebasin.com/index.php/Dungeon-Building_Algorithm
  */
 export default class Digger extends Dungeon {
 	_options: Options;

--- a/src/map/iceymaze.ts
+++ b/src/map/iceymaze.ts
@@ -3,7 +3,7 @@ import RNG from "../rng.js";
 
 /**
  * Icey's Maze generator
- * See http://www.roguebasin.roguelikedevelopment.org/index.php?title=Simple_maze for explanation
+ * See http://roguebasin.com/index.php/Simple_maze for explanation
  */
 export default class IceyMaze extends Map {
 	_regularity: number;

--- a/src/stringgenerator.ts
+++ b/src/stringgenerator.ts
@@ -13,7 +13,7 @@ type Events = { [key:string]: number };
 
 /**
  * @class (Markov process)-based string generator. 
- * Copied from a <a href="http://www.roguebasin.roguelikedevelopment.org/index.php?title=Names_from_a_high_order_Markov_Process_and_a_simplified_Katz_back-off_scheme">RogueBasin article</a>. 
+ * Copied from a <a href="http://roguebasin.com/index.php/Names_from_a_high_order_Markov_Process_and_a_simplified_Katz_back-off_scheme">RogueBasin article</a>. 
  * Offers configurable order and prior.
  */
 export default class StringGenerator {


### PR DESCRIPTION
This fixes a few broken RogueBasin links that I noticed during my 7DRL.

I also tried building the project using `make all` but it ended up with a *lot* of differences that appeared not to affect anything but would probably make this harder to review. The results are [here](https://github.com/katerberg/rot.js/tree/built). I'm happy to have that be the PR instead if that's easier, but I'm likely doing something wrong with my build process, or some backing libraries have updated and now there is not a need for the `_partial` prefixing anymore.

I'm happy to document the build process if that would be useful, but I'm not sure how to get it compiled and working.