### PR TITLE
Fix canvas clear when background is transparent/translucent

### DIFF
--- a/src/display/canvas.ts
+++ b/src/display/canvas.ts
@@ -26,8 +26,11 @@ export default abstract class Canvas extends Backend {
 	}
 
 	clear() {
+		const oldComposite = this._ctx.globalCompositeOperation;
+		this._ctx.globalCompositeOperation = "copy"
 		this._ctx.fillStyle = this._options.bg;
 		this._ctx.fillRect(0, 0, this._ctx.canvas.width, this._ctx.canvas.height);
+		this._ctx.globalCompositeOperation = oldComposite;
 	}
 
 	eventToPosition(x: number, y: number): [number, number] {


### PR DESCRIPTION
This can also be applied to e.g. Tile.draw() when clearBefore is true and tileColorize is false