### PR TITLE
Display/Backend refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .ts.flag
 .idea
 .DS_Store
+*.tsbuildinfo

--- a/src/display/backend.ts
+++ b/src/display/backend.ts
@@ -1,20 +1,35 @@
-import { DisplayOptions, DisplayData, IDisplayBackend } from "./types.js";
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from "../constants.js";
+import { DisplayOptions, DisplayData, IDisplayBackend, DefaultsFor, Frozen, BaseDisplayOptions } from "./types.js";
 
 /**
  * @class Abstract display backend module
  * @private
  */
-export default abstract class Backend implements IDisplayBackend {
-	_options!: DisplayOptions;
+export default abstract class Backend<TOptions extends BaseDisplayOptions = BaseDisplayOptions>
+							implements IDisplayBackend<TOptions> {
+	protected get DEFAULTS() {
+		return {
+			width: DEFAULT_WIDTH,
+			height: DEFAULT_HEIGHT,
+			layout: "rect",
+			fg: "#ccc",
+			bg: "#000",
+		} satisfies DefaultsFor<BaseDisplayOptions>;
+	}
+	_options!: Frozen<TOptions>;
 
 	getContainer(): HTMLElement | null { return null; }
 
-	abstract checkOptions(options: DisplayOptions): boolean;
-	setOptions(options: DisplayOptions) {
+	abstract checkOptions(options: DisplayOptions): options is DisplayOptions & TOptions;
+	setOptions(options: TOptions) {
 		// return true if this change dirties the whole display
 		const { width, height, layout } = this._options ?? {};
-		this._options = {...options};
+		this._options = this.defaultedOptions(options);
 		return width !== options.width || height !== options.height || layout !== options.layout;
+	}
+	protected abstract defaultedOptions(options: TOptions): Frozen<TOptions>;
+	getOptions(): Frozen<TOptions> {
+		return this._options as Frozen<TOptions>;
 	}
 
 	abstract schedule(cb: ()=>void): void;

--- a/src/display/backend.ts
+++ b/src/display/backend.ts
@@ -1,14 +1,21 @@
-import { DisplayOptions, DisplayData } from "./types.js";
+import { DisplayOptions, DisplayData, IDisplayBackend } from "./types.js";
 
 /**
  * @class Abstract display backend module
  * @private
  */
-export default abstract class Backend {
+export default abstract class Backend implements IDisplayBackend {
 	_options!: DisplayOptions;
 
 	getContainer(): HTMLElement | null { return null; }
-	setOptions(options: DisplayOptions) { this._options = options; }
+
+	abstract checkOptions(options: DisplayOptions): boolean;
+	setOptions(options: DisplayOptions) {
+		// return true if this change dirties the whole display
+		const { width, height, layout } = this._options ?? {};
+		this._options = {...options};
+		return width !== options.width || height !== options.height || layout !== options.layout;
+	}
 
 	abstract schedule(cb: ()=>void): void;
 	abstract clear(): void;

--- a/src/display/backend.ts
+++ b/src/display/backend.ts
@@ -5,8 +5,11 @@ import { DisplayOptions, DisplayData, IDisplayBackend, DefaultsFor, Frozen, Base
  * @class Abstract display backend module
  * @private
  */
-export default abstract class Backend<TOptions extends BaseDisplayOptions = BaseDisplayOptions>
-							implements IDisplayBackend<TOptions> {
+export default abstract class Backend<TOptions extends BaseDisplayOptions = BaseDisplayOptions,
+									  TChar = string, TFGColor = string, TBGColor = string,
+									  TData extends DisplayData<TChar, TFGColor, TBGColor> = DisplayData<TChar, TFGColor, TBGColor>,
+									 >
+							implements IDisplayBackend<TOptions, TData> {
 	protected get DEFAULTS() {
 		return {
 			width: DEFAULT_WIDTH,
@@ -34,7 +37,7 @@ export default abstract class Backend<TOptions extends BaseDisplayOptions = Base
 
 	abstract schedule(cb: ()=>void): void;
 	abstract clear(): void;
-	abstract draw(data: DisplayData, clearBefore: boolean): void;
+	abstract draw(data: TData, clearBefore: boolean): void;
 	abstract computeSize(availWidth: number, availHeight: number): [number, number];
 	abstract computeFontSize(availWidth: number, availHeight: number): number;
 	abstract eventToPosition(x:number, y:number): [number, number];

--- a/src/display/canvas.ts
+++ b/src/display/canvas.ts
@@ -1,10 +1,10 @@
 import Backend from "./backend.js";
-import { DisplayOptions, UnknownBackend } from "./types.js";
+import { BaseDisplayOptions, TextDisplayOptions, UnknownBackend, DefaultsFor } from "./types.js";
 
 /**
  * Base class for any backend that uses a `<canvas>` element as its display surface
  */
-export abstract class BaseCanvas extends Backend {
+export abstract class BaseCanvas<TOptions extends BaseDisplayOptions> extends Backend<TOptions> {
 	_ctx: CanvasRenderingContext2D;
 
 	constructor(oldBackend?: UnknownBackend) {
@@ -15,7 +15,7 @@ export abstract class BaseCanvas extends Backend {
 	schedule(cb: () => void) { requestAnimationFrame(cb); }
 	getContainer() { return this._ctx.canvas; }
 
-	setOptions(opts: DisplayOptions) {
+	setOptions(opts: TOptions) {
 		let needsRepaint = super.setOptions(opts);
 
 		if (needsRepaint) {
@@ -54,8 +54,18 @@ export abstract class BaseCanvas extends Backend {
 /**
  * Base class for text canvases, which can display one or more text characters with a single foreground and a background color in each cell.
  */
-export default abstract class Canvas extends BaseCanvas {
-	setOptions(opts: DisplayOptions) {
+export default abstract class Canvas<TOptions extends TextDisplayOptions> extends BaseCanvas<TOptions> {
+	protected get DEFAULTS() {
+		return {
+			...super.DEFAULTS,
+			fontSize: 15,
+			spacing: 1,
+			border: 0,
+			fontFamily: "monospace",
+			fontStyle: "",
+		} satisfies DefaultsFor<TextDisplayOptions>;
+	}
+	setOptions(opts: TOptions) {
 		const { fontSize, fontFamily, spacing } = this._options;
 		let needsRepaint = super.setOptions(opts) || fontSize !== opts.fontSize || fontFamily !== opts.fontFamily || spacing !== opts.spacing;
 

--- a/src/display/canvas.ts
+++ b/src/display/canvas.ts
@@ -1,10 +1,14 @@
 import Backend from "./backend.js";
-import { BaseDisplayOptions, TextDisplayOptions, UnknownBackend, DefaultsFor } from "./types.js";
+import { BaseDisplayOptions, DisplayData, TextDisplayOptions, UnknownBackend, DefaultsFor } from "./types.js";
 
 /**
  * Base class for any backend that uses a `<canvas>` element as its display surface
  */
-export abstract class BaseCanvas<TOptions extends BaseDisplayOptions> extends Backend<TOptions> {
+export abstract class BaseCanvas<TOptions extends BaseDisplayOptions,
+								 TData extends DisplayData = DisplayData<string[], string, string>,
+								 TChar = string[], TFGColor = string, TBGColor = string,
+								>
+						extends Backend<TOptions, TChar, TFGColor, TBGColor, TData extends DisplayData<TChar, TFGColor, TBGColor> ? TData : never> {
 	_ctx: CanvasRenderingContext2D;
 
 	constructor(oldBackend?: UnknownBackend) {
@@ -51,10 +55,15 @@ export abstract class BaseCanvas<TOptions extends BaseDisplayOptions> extends Ba
 	abstract _updateSize(): void;
 }
 
+export type CanvasDisplayData = DisplayData<string[], string, string>;
 /**
  * Base class for text canvases, which can display one or more text characters with a single foreground and a background color in each cell.
  */
-export default abstract class Canvas<TOptions extends TextDisplayOptions> extends BaseCanvas<TOptions> {
+export default abstract class Canvas<TOptions extends TextDisplayOptions,
+									 TData extends DisplayData = CanvasDisplayData,
+									 TChar = string[], TFGColor = string, TBGColor = string,
+									>
+							extends BaseCanvas<TOptions, TData, TChar, TFGColor, TBGColor> {
 	protected get DEFAULTS() {
 		return {
 			...super.DEFAULTS,

--- a/src/display/canvas.ts
+++ b/src/display/canvas.ts
@@ -26,11 +26,11 @@ export default abstract class Canvas extends Backend {
 	}
 
 	clear() {
-		const oldComposite = this._ctx.globalCompositeOperation;
+		this._ctx.save();
 		this._ctx.globalCompositeOperation = "copy"
 		this._ctx.fillStyle = this._options.bg;
 		this._ctx.fillRect(0, 0, this._ctx.canvas.width, this._ctx.canvas.height);
-		this._ctx.globalCompositeOperation = oldComposite;
+		this._ctx.restore();
 	}
 
 	eventToPosition(x: number, y: number): [number, number] {

--- a/src/display/display.ts
+++ b/src/display/display.ts
@@ -365,8 +365,11 @@ export interface Display<TLayout extends LayoutType = LayoutType, TChar = Layout
 }
 
 type LayoutFor<TOptions extends DisplayOptions> = TOptions extends {layout: infer L} ? NonNullable<L> : typeof DisplayImpl["DEFAULT_LAYOUT"];
-type BackendFor<TOptions extends DisplayOptions> = LayoutBackend<LayoutFor<TOptions>>;
-type TCharFromOptions<TOptions extends DisplayOptions> = BackendChars<BackendFor<TOptions>>;
+type BackendFor<TOptions extends DisplayOptions> = LayoutBackend<LayoutFor<TOptions>, TOptions>;
+type TCharFromOptions<TOptions extends DisplayOptions> =
+	TOptions extends {tileMap: Record<infer TKey, any>} ? TKey[]
+	: TOptions extends {tileMap: readonly any[]} ? number[]
+	: BackendChars<BackendFor<TOptions>>;
 type TFGColorFromOptions<TOptions extends DisplayOptions> = BackendFGColor<BackendFor<TOptions>>;
 type TBGColorFromOptions<TOptions extends DisplayOptions> = BackendBGColor<BackendFor<TOptions>>;
 
@@ -384,6 +387,6 @@ export interface DisplayConstructor {
 }
 
 export const Display = class Display<TLayout extends LayoutType, TChar, TFGColor, TBGColor> extends DisplayImpl<TLayout, TChar, TFGColor, TBGColor> {
-} as any;
+} as unknown as DisplayConstructor;
 
 export default Display;

--- a/src/display/hex.ts
+++ b/src/display/hex.ts
@@ -1,5 +1,5 @@
 import Canvas from "./canvas.js";
-import { DisplayOptions, DisplayData } from "./types.js";
+import { TextDisplayOptions, DisplayData, DefaultsFor, DisplayOptions } from "./types.js";
 import { mod } from "../util.js";
 
 declare module "./types.js" {
@@ -8,19 +8,36 @@ declare module "./types.js" {
 	}
 }
 
+export interface HexOptions extends TextDisplayOptions {
+	layout: "hex";
+	transpose?: boolean;
+}
+
 /**
  * @class Hexagonal backend
  * @private
  */
-export default class Hex extends Canvas {
+export default class Hex extends Canvas<HexOptions> {
+	protected get DEFAULTS() {
+		return {
+			...super.DEFAULTS,
+			transpose: false
+		} satisfies DefaultsFor<HexOptions>;
+	}
 	_spacingX = 0;
 	_spacingY = 0;
 	_hexSize = 0;
 
-	checkOptions(options: DisplayOptions): boolean {
+	checkOptions(options: DisplayOptions): options is HexOptions {
 		return options.layout === "hex";
 	}
 
+	protected defaultedOptions(options: HexOptions): Required<HexOptions> {
+		return {
+			...this.DEFAULTS,
+			...options,
+		}
+	}
 	draw(data: DisplayData, clearBefore: boolean) {
 		const {x, y, chars, fg, bg} = data;
 

--- a/src/display/hex.ts
+++ b/src/display/hex.ts
@@ -1,25 +1,28 @@
 import Canvas from "./canvas.js";
-import { DisplayData } from "./types.js";
+import { DisplayOptions, DisplayData } from "./types.js";
 import { mod } from "../util.js";
+
+declare module "./types.js" {
+	interface LayoutTypeBackendMap {
+		hex: Hex;
+	}
+}
 
 /**
  * @class Hexagonal backend
  * @private
  */
 export default class Hex extends Canvas {
-	_spacingX: number;
-	_spacingY: number;
-	_hexSize: number;
+	_spacingX = 0;
+	_spacingY = 0;
+	_hexSize = 0;
 
-	constructor() {
-		super();
-		this._spacingX = 0;
-		this._spacingY = 0;
-		this._hexSize = 0;
+	checkOptions(options: DisplayOptions): boolean {
+		return options.layout === "hex";
 	}
 
 	draw(data: DisplayData, clearBefore: boolean) {
-		let [x, y, ch, fg, bg] = data;
+		const {x, y, chars, fg, bg} = data;
 
 		let px = [
 			(x+1) * this._spacingX,
@@ -32,11 +35,10 @@ export default class Hex extends Canvas {
 			this._fill(px[0], px[1]);
 		}
 
-		if (!ch) { return; }
+		if (!chars.length) { return; }
 
 		this._ctx.fillStyle = fg;
 
-		let chars = ([] as string[]).concat(ch);
 		for (let i=0;i<chars.length;i++) {
 			this._ctx.fillText(chars[i], px[0], Math.ceil(px[1]));
 		}

--- a/src/display/hex.ts
+++ b/src/display/hex.ts
@@ -3,7 +3,7 @@ import { TextDisplayOptions, DefaultsFor, DisplayOptions } from "./types.js";
 import { mod } from "../util.js";
 
 declare module "./types.js" {
-	interface LayoutTypeBackendMap {
+	interface LayoutTypeBackendMap<TOptions extends DisplayOptions> {
 		hex: Hex;
 	}
 }

--- a/src/display/hex.ts
+++ b/src/display/hex.ts
@@ -1,5 +1,5 @@
-import Canvas from "./canvas.js";
-import { TextDisplayOptions, DisplayData, DefaultsFor, DisplayOptions } from "./types.js";
+import Canvas, { CanvasDisplayData } from "./canvas.js";
+import { TextDisplayOptions, DefaultsFor, DisplayOptions } from "./types.js";
 import { mod } from "../util.js";
 
 declare module "./types.js" {
@@ -12,12 +12,14 @@ export interface HexOptions extends TextDisplayOptions {
 	layout: "hex";
 	transpose?: boolean;
 }
+export interface HexData extends CanvasDisplayData {
+}
 
 /**
  * @class Hexagonal backend
  * @private
  */
-export default class Hex extends Canvas<HexOptions> {
+export default class Hex extends Canvas<HexOptions, HexData> {
 	protected get DEFAULTS() {
 		return {
 			...super.DEFAULTS,
@@ -38,7 +40,7 @@ export default class Hex extends Canvas<HexOptions> {
 			...options,
 		}
 	}
-	draw(data: DisplayData, clearBefore: boolean) {
+	draw(data: HexData, clearBefore: boolean) {
 		const {x, y, chars, fg, bg} = data;
 
 		let px = [

--- a/src/display/rect.ts
+++ b/src/display/rect.ts
@@ -2,7 +2,7 @@ import Canvas, { CanvasDisplayData } from "./canvas.js";
 import { DefaultsFor, DisplayOptions, TextDisplayOptions } from "./types.js";
 
 declare module "./types.js" {
-	interface LayoutTypeBackendMap {
+	interface LayoutTypeBackendMap<TOptions extends DisplayOptions> {
 		rect: Rect;
 	}
 }

--- a/src/display/rect.ts
+++ b/src/display/rect.ts
@@ -1,5 +1,5 @@
-import Canvas from "./canvas.js";
-import { DefaultsFor, DisplayData, DisplayOptions, TextDisplayOptions } from "./types.js";
+import Canvas, { CanvasDisplayData } from "./canvas.js";
+import { DefaultsFor, DisplayOptions, TextDisplayOptions } from "./types.js";
 
 declare module "./types.js" {
 	interface LayoutTypeBackendMap {
@@ -12,11 +12,14 @@ export interface RectOptions extends TextDisplayOptions {
 	forceSquareRatio?: boolean;
 }
 
+export interface RectData extends CanvasDisplayData {
+}
+
 /**
  * @class Rectangular backend
  * @private
  */
-export default class Rect extends Canvas<RectOptions> {
+export default class Rect extends Canvas<RectOptions, RectData> {
 	protected get DEFAULTS() {
 		return {
 			...super.DEFAULTS,
@@ -44,7 +47,7 @@ export default class Rect extends Canvas<RectOptions> {
 		}
 	}
 
-	draw(data: DisplayData, clearBefore: boolean) {
+	draw(data: RectData, clearBefore: boolean) {
 		if (Rect.cache) {
 			this._drawWithCache(data);
 		} else {
@@ -52,7 +55,7 @@ export default class Rect extends Canvas<RectOptions> {
 		}
 	}
 
-	_drawWithCache(data: DisplayData) {
+	_drawWithCache(data: RectData) {
 		const {x, y, ch, chars, fg, bg} = data;
 
 		let hash = ""+ch+fg+bg;
@@ -84,7 +87,7 @@ export default class Rect extends Canvas<RectOptions> {
 		this._ctx.drawImage(canvas, x*this._spacingX, y*this._spacingY);
 	}
 
-	_drawNoCache(data: DisplayData, clearBefore: boolean) {
+	_drawNoCache(data: RectData, clearBefore: boolean) {
 		const {x, y, chars, fg, bg} = data;
 
 		if (clearBefore) { 

--- a/src/display/rect.ts
+++ b/src/display/rect.ts
@@ -1,5 +1,5 @@
 import Canvas from "./canvas.js";
-import { DisplayOptions, DisplayData } from "./types.js";
+import { DefaultsFor, DisplayData, DisplayOptions, TextDisplayOptions } from "./types.js";
 
 declare module "./types.js" {
 	interface LayoutTypeBackendMap {
@@ -7,23 +7,41 @@ declare module "./types.js" {
 	}
 }
 
+export interface RectOptions extends TextDisplayOptions {
+	layout?: "rect";
+	forceSquareRatio?: boolean;
+}
+
 /**
  * @class Rectangular backend
  * @private
  */
-export default class Rect extends Canvas {
+export default class Rect extends Canvas<RectOptions> {
+	protected get DEFAULTS() {
+		return {
+			...super.DEFAULTS,
+			forceSquareRatio: false,
+		} satisfies DefaultsFor<RectOptions>;
+	}
 	_spacingX: number = 0;
 	_spacingY: number = 0;
 	_canvasCache: {[key:string]: HTMLCanvasElement} = {};
 
 	static cache = false;
 
-	checkOptions(options: DisplayOptions): boolean {
+	checkOptions(options: DisplayOptions): options is RectOptions {
 		return options.layout === "rect" || !options.layout;
 	}
-	setOptions(options: DisplayOptions) {
+	setOptions(options: RectOptions) {
 		this._canvasCache = {};
 		return super.setOptions(options);
+	}
+
+	protected defaultedOptions(options: RectOptions): Required<RectOptions> {
+		return {
+			...this.DEFAULTS,
+			...options,
+		}
 	}
 
 	draw(data: DisplayData, clearBefore: boolean) {

--- a/src/display/rect.ts
+++ b/src/display/rect.ts
@@ -1,28 +1,29 @@
 import Canvas from "./canvas.js";
 import { DisplayOptions, DisplayData } from "./types.js";
 
+declare module "./types.js" {
+	interface LayoutTypeBackendMap {
+		rect: Rect;
+	}
+}
+
 /**
  * @class Rectangular backend
  * @private
  */
 export default class Rect extends Canvas {
-	_spacingX: number;
-	_spacingY: number;
-	_canvasCache: {[key:string]: HTMLCanvasElement};
-	_options!: DisplayOptions;
+	_spacingX: number = 0;
+	_spacingY: number = 0;
+	_canvasCache: {[key:string]: HTMLCanvasElement} = {};
 
 	static cache = false;
 
-	constructor() {
-		super();
-		this._spacingX = 0;
-		this._spacingY = 0;
-		this._canvasCache = {};
+	checkOptions(options: DisplayOptions): boolean {
+		return options.layout === "rect" || !options.layout;
 	}
-
 	setOptions(options: DisplayOptions) {
-		super.setOptions(options);
 		this._canvasCache = {};
+		return super.setOptions(options);
 	}
 
 	draw(data: DisplayData, clearBefore: boolean) {
@@ -34,7 +35,7 @@ export default class Rect extends Canvas {
 	}
 
 	_drawWithCache(data: DisplayData) {
-		let [x, y, ch, fg, bg] = data;
+		const {x, y, ch, chars, fg, bg} = data;
 
 		let hash = ""+ch+fg+bg;
 		let canvas;
@@ -49,13 +50,12 @@ export default class Rect extends Canvas {
 			ctx.fillStyle = bg;
 			ctx.fillRect(b, b, canvas.width-b, canvas.height-b);
 			
-			if (ch) {
+			if (chars.length) {
 				ctx.fillStyle = fg;
 				ctx.font = this._ctx.font;
 				ctx.textAlign = "center";
 				ctx.textBaseline = "middle";
 
-				let chars = ([] as string[]).concat(ch);
 				for (let i=0;i<chars.length;i++) {
 					ctx.fillText(chars[i], this._spacingX/2, Math.ceil(this._spacingY/2));
 				}
@@ -67,7 +67,7 @@ export default class Rect extends Canvas {
 	}
 
 	_drawNoCache(data: DisplayData, clearBefore: boolean) {
-		let [x, y, ch, fg, bg] = data;
+		const {x, y, chars, fg, bg} = data;
 
 		if (clearBefore) { 
 			let b = this._options.border;
@@ -75,11 +75,10 @@ export default class Rect extends Canvas {
 			this._ctx.fillRect(x*this._spacingX + b, y*this._spacingY + b, this._spacingX - b, this._spacingY - b);
 		}
 		
-		if (!ch) { return; }
+		if (!chars.length) { return; }
 
 		this._ctx.fillStyle = fg;
 
-		let chars = ([] as string[]).concat(ch);
 		for (let i=0;i<chars.length;i++) {
 			this._ctx.fillText(chars[i], (x+0.5) * this._spacingX, Math.ceil((y+0.5) * this._spacingY));
 		}

--- a/src/display/term.ts
+++ b/src/display/term.ts
@@ -1,6 +1,12 @@
 import Backend from "./backend.js";
-import { DisplayData, DisplayOptions } from "./types.js";
+import { DisplayOptions, DisplayData } from "./types.js";
 import * as Color from "../color.js";
+
+declare module "./types.js" {
+	interface LayoutTypeBackendMap {
+		term: Term;
+	}
+}
 
 // Explicitly declaring this so that including projects don't need to import node types
 declare global {
@@ -56,11 +62,15 @@ export default class Term extends Backend {
 
 	schedule(cb: ()=>void) { setTimeout(cb, 1000/60); }
 
+	checkOptions(options: DisplayOptions): boolean {
+		return options.layout === "term";
+	}
 	setOptions(options: DisplayOptions) {
-		super.setOptions(options);
-		let size = [options.width, options.height];
+		let needsRepaint = super.setOptions(options);
+		let size = [this._options.width, this._options.height];
 		let avail = this.computeSize();
 		this._offset = avail.map((val, index) => Math.floor((val as number - size[index])/2)) as [number, number];
+		return needsRepaint;
 	}
 
 	clear() {
@@ -69,7 +79,7 @@ export default class Term extends Backend {
 
 	draw(data: DisplayData, clearBefore: boolean) {
 		// determine where to draw what with what colors
-		let [x, y, ch, fg, bg] = data;
+		let {x, y, ch, fg, bg} = data;
 
 		// determine if we need to move the terminal cursor
 		let dx = this._offset[0] + x;

--- a/src/display/term.ts
+++ b/src/display/term.ts
@@ -3,7 +3,7 @@ import { BaseDisplayOptions, DisplayData, DisplayOptions } from "./types.js";
 import * as Color from "../color.js";
 
 declare module "./types.js" {
-	interface LayoutTypeBackendMap {
+	interface LayoutTypeBackendMap<TOptions extends DisplayOptions> {
 		term: Term;
 	}
 }

--- a/src/display/term.ts
+++ b/src/display/term.ts
@@ -2,6 +2,22 @@ import Backend from "./backend.js";
 import { DisplayData, DisplayOptions } from "./types.js";
 import * as Color from "../color.js";
 
+// Explicitly declaring this so that including projects don't need to import node types
+declare global {
+	namespace NodeJS {
+		interface WriteStream 
+		{
+			rows: number;
+			columns: number;
+			write(data: string): any;
+		}
+		interface Process {
+			stdout: WriteStream & { fd: 1; } 
+		}
+	}
+	var process: NodeJS.Process;
+}
+
 function clearToAnsi(bg: string) {
 	return `\x1b[0;48;5;${termcolor(bg)}m\x1b[2J`;
 }

--- a/src/display/term.ts
+++ b/src/display/term.ts
@@ -1,5 +1,5 @@
 import Backend from "./backend.js";
-import { DisplayOptions, DisplayData } from "./types.js";
+import { DisplayOptions, DisplayData, BaseDisplayOptions } from "./types.js";
 import * as Color from "../color.js";
 
 declare module "./types.js" {
@@ -47,8 +47,11 @@ function termcolor(color: string) {
 	return r*36 + g*6 + b*1 + 16;
 }
 
+export interface TermOptions extends BaseDisplayOptions {
+	layout: "term";
+}
 
-export default class Term extends Backend {
+export default class Term extends Backend<TermOptions> {
 	_offset: [number, number];
 	_cursor: [number, number];
 	_lastColor: string;
@@ -62,15 +65,24 @@ export default class Term extends Backend {
 
 	schedule(cb: ()=>void) { setTimeout(cb, 1000/60); }
 
-	checkOptions(options: DisplayOptions): boolean {
+	checkOptions(options: DisplayOptions): options is TermOptions {
 		return options.layout === "term";
 	}
-	setOptions(options: DisplayOptions) {
+	setOptions(options: TermOptions) {
 		let needsRepaint = super.setOptions(options);
 		let size = [this._options.width, this._options.height];
 		let avail = this.computeSize();
 		this._offset = avail.map((val, index) => Math.floor((val as number - size[index])/2)) as [number, number];
 		return needsRepaint;
+	}
+
+	protected defaultedOptions(options: TermOptions): Required<TermOptions> {
+		const [width, height] = this.computeSize();
+		return {
+			...this.DEFAULTS,
+			width, height,
+			...options,
+		};
 	}
 
 	clear() {

--- a/src/display/term.ts
+++ b/src/display/term.ts
@@ -1,5 +1,5 @@
 import Backend from "./backend.js";
-import { DisplayOptions, DisplayData, BaseDisplayOptions } from "./types.js";
+import { BaseDisplayOptions, DisplayData, DisplayOptions } from "./types.js";
 import * as Color from "../color.js";
 
 declare module "./types.js" {
@@ -50,8 +50,10 @@ function termcolor(color: string) {
 export interface TermOptions extends BaseDisplayOptions {
 	layout: "term";
 }
+export interface TermData extends DisplayData<string, string, string> {
+}
 
-export default class Term extends Backend<TermOptions> {
+export default class Term extends Backend<TermOptions, string, string, string, TermData> {
 	_offset: [number, number];
 	_cursor: [number, number];
 	_lastColor: string;
@@ -89,7 +91,7 @@ export default class Term extends Backend<TermOptions> {
 		process.stdout.write(clearToAnsi(this._options.bg));
 	}
 
-	draw(data: DisplayData, clearBefore: boolean) {
+	draw(data: TermData, clearBefore: boolean) {
 		// determine where to draw what with what colors
 		let {x, y, ch, fg, bg} = data;
 

--- a/src/display/tile-gl.ts
+++ b/src/display/tile-gl.ts
@@ -11,12 +11,14 @@ declare module "./types.js" {
 export interface TileGLOptions extends TileDisplayOptions {
 	layout: "tile-gl";
 }
+export interface TileGLData extends DisplayData<string[], string[], string[]> {
+}
 
 /**
  * @class Tile backend
  * @private
  */
-export default class TileGL extends Backend<TileGLOptions> {
+export default class TileGL extends Backend<TileGLOptions, string[], string[], string[], TileGLData> {
 	_gl!: WebGLRenderingContext;
 	_program!: WebGLProgram;
 	_uniforms: {[key:string]: WebGLUniformLocation | null};
@@ -76,7 +78,7 @@ export default class TileGL extends Backend<TileGLOptions> {
 		}
 	}
 
-	draw(data: DisplayData, clearBefore: boolean) {
+	draw(data: TileGLData, clearBefore: boolean) {
 		const gl = this._gl;
 		const opts = this._options;
 		const {x, y, chars, fgs, bgs} = data;

--- a/src/display/tile.ts
+++ b/src/display/tile.ts
@@ -10,14 +10,15 @@ declare module "./types.js" {
 export interface TileOptions<TChar extends TileMapKey = string> extends TileDisplayOptions<TChar> {
 	layout: "tile";
 }
-export interface TileData<TChar extends TileMapKey> extends DisplayData<TChar[], string[], string[]> {
+type TileFGColor = string | number; // string = color, number = opacity
+export interface TileData<TChar extends TileMapKey> extends DisplayData<TChar[], TileFGColor[], string[]> {
 }
 
 /**
  * @class Tile backend
  * @private
  */
-export default class Tile<TChar extends TileMapKey = string> extends BaseCanvas<TileOptions<TChar>, TileData<TChar>, TChar[], string[], string[]> {
+export default class Tile<TChar extends TileMapKey = string> extends BaseCanvas<TileOptions<TChar>, TileData<TChar>, TChar[], TileFGColor[], string[]> {
 	_colorCanvas: HTMLCanvasElement;
 
 	protected get DEFAULTS() {
@@ -87,7 +88,7 @@ export default class Tile<TChar extends TileMapKey = string> extends BaseCanvas<
 					0, 0, tileWidth, tileHeight
 				);
 
-				if (fg != "transparent") {
+				if (typeof fg === "string" && fg != "transparent") {
 					context.fillStyle = fg;
 					context.globalCompositeOperation = "source-atop";
 					context.fillRect(0, 0, tileWidth, tileHeight);
@@ -99,8 +100,15 @@ export default class Tile<TChar extends TileMapKey = string> extends BaseCanvas<
 					context.fillRect(0, 0, tileWidth, tileHeight);
 				}
 
+				if (typeof fg === "number") {
+					this._ctx.globalAlpha = fg;
+				}
 				this._ctx.drawImage(canvas, x*tileWidth, y*tileHeight, tileWidth, tileHeight);
 			} else { // no colorizing, easy
+				let fg = fgs[i];
+				if (typeof fg === "number") {
+					this._ctx.globalAlpha = fg;
+				}
 				this._ctx.drawImage(
 					this._options.tileSet!,
 					tile[0], tile[1], tileWidth, tileHeight,
@@ -108,6 +116,7 @@ export default class Tile<TChar extends TileMapKey = string> extends BaseCanvas<
 				);
 			}
 		}
+		this._ctx.globalAlpha = 1;
 	}
 
 	computeSize(availWidth: number, availHeight: number): [number, number] {

--- a/src/display/tile.ts
+++ b/src/display/tile.ts
@@ -10,12 +10,14 @@ declare module "./types.js" {
 export interface TileOptions extends TileDisplayOptions {
 	layout: "tile";
 }
+export interface TileData extends DisplayData<string[], string[], string[]> {
+}
 
 /**
  * @class Tile backend
  * @private
  */
-export default class Tile extends BaseCanvas<TileOptions> {
+export default class Tile extends BaseCanvas<TileOptions, TileData, string[], string[], string[]> {
 	_colorCanvas: HTMLCanvasElement;
 
 	protected get DEFAULTS() {
@@ -43,7 +45,7 @@ export default class Tile extends BaseCanvas<TileOptions> {
 		}
 	}
 
-	draw(data: DisplayData, clearBefore: boolean) {
+	draw(data: TileData, clearBefore: boolean) {
 		const {x, y, chars, fgs, bgs} = data;
 
 		let tileWidth = this._options.tileWidth;

--- a/src/display/tile.ts
+++ b/src/display/tile.ts
@@ -1,5 +1,5 @@
 import { BaseCanvas } from "./canvas.js";
-import { DisplayOptions, DisplayData, UnknownBackend } from "./types.js";
+import { TileDisplayOptions, DisplayData, UnknownBackend, DefaultsFor, DisplayOptions } from "./types.js";
 
 declare module "./types.js" {
 	interface LayoutTypeBackendMap {
@@ -7,20 +7,40 @@ declare module "./types.js" {
 	}
 }
 
+export interface TileOptions extends TileDisplayOptions {
+	layout: "tile";
+}
+
 /**
  * @class Tile backend
  * @private
  */
-export default class Tile extends BaseCanvas {
+export default class Tile extends BaseCanvas<TileOptions> {
 	_colorCanvas: HTMLCanvasElement;
+
+	protected get DEFAULTS() {
+		return {
+			...super.DEFAULTS,
+			tileWidth: 32,
+			tileHeight: 32,
+			tileColorize: false,
+		} satisfies DefaultsFor<TileOptions>;
+	}
 
 	constructor(oldBackend?: UnknownBackend) {
 		super(oldBackend);
 		this._colorCanvas = oldBackend instanceof Tile ? oldBackend._colorCanvas : document.createElement("canvas");
 	}
 
-	checkOptions(options: DisplayOptions): boolean {
+	checkOptions(options: DisplayOptions): options is TileOptions {
 		return options.layout === "tile";
+	}
+
+	protected defaultedOptions(options: TileOptions): Required<TileOptions> {
+		return {
+			...this.DEFAULTS,
+			...options,
+		}
 	}
 
 	draw(data: DisplayData, clearBefore: boolean) {

--- a/src/display/tile.ts
+++ b/src/display/tile.ts
@@ -23,8 +23,14 @@ export default class Tile extends Canvas {
 			if (this._options.tileColorize) {
 				this._ctx.clearRect(x*tileWidth, y*tileHeight, tileWidth, tileHeight);
 			} else {
+                this._ctx.save();
+                this._ctx.globalCompositeOperation = "copy";
 				this._ctx.fillStyle = bg;
-				this._ctx.fillRect(x*tileWidth, y*tileHeight, tileWidth, tileHeight);
+                this._ctx.beginPath();
+                this._ctx.rect(x*tileWidth, y*tileHeight, tileWidth, tileHeight);
+                this._ctx.clip();
+                this._ctx.fill();
+                this._ctx.restore();
 			}
 		}
 

--- a/src/display/types.ts
+++ b/src/display/types.ts
@@ -1,8 +1,8 @@
-export interface LayoutTypeBackendMap {
+export interface LayoutTypeBackendMap<TOptions extends DisplayOptions> {
 	// Entries in this map are added via declaration merging, see the top of e.g. rect.ts
 }
 
-export type LayoutType = {[TLayout in keyof LayoutTypeBackendMap]: TLayout}[keyof LayoutTypeBackendMap];
+export type LayoutType = {[TLayout in keyof LayoutTypeBackendMap<any>]: TLayout}[keyof LayoutTypeBackendMap<any>];
 export type AnyBackend = IDisplayBackend<any, any>;
 export type UnknownBackend = IDisplayBackend<BaseDisplayOptions, DisplayData>;
 
@@ -11,11 +11,11 @@ export type BackendChars<TBackend extends AnyBackend> = TBackend extends IDispla
 export type BackendFGColor<TBackend extends AnyBackend> = TBackend extends IDisplayBackend<any, infer TData> ? TData["fg"] : never;
 export type BackendBGColor<TBackend extends AnyBackend> = TBackend extends IDisplayBackend<any, infer TData> ? TData["bg"] : never;
 
-export type LayoutBackend<TLayout extends LayoutType> = LayoutTypeBackendMap[TLayout];
-export type LayoutOptions<TLayout extends LayoutType> = BackendOptions<LayoutBackend<TLayout>>
-export type LayoutChars<TLayout extends LayoutType> = BackendChars<LayoutBackend<TLayout>>
-export type LayoutFGColor<TLayout extends LayoutType> = BackendFGColor<LayoutBackend<TLayout>>
-export type LayoutBGColor<TLayout extends LayoutType> = BackendBGColor<LayoutBackend<TLayout>>
+export type LayoutBackend<TLayout extends LayoutType, TOptions extends DisplayOptions> = LayoutTypeBackendMap<TOptions>[TLayout];
+export type LayoutOptions<TLayout extends LayoutType> = BackendOptions<LayoutBackend<TLayout, any>>
+export type LayoutChars<TLayout extends LayoutType, TOptions extends DisplayOptions = {}> = BackendChars<LayoutBackend<TLayout, TOptions>>
+export type LayoutFGColor<TLayout extends LayoutType, TOptions extends DisplayOptions = {}> = BackendFGColor<LayoutBackend<TLayout, TOptions>>
+export type LayoutBGColor<TLayout extends LayoutType, TOptions extends DisplayOptions = {}> = BackendBGColor<LayoutBackend<TLayout, TOptions>>
 
 export interface BaseDisplayOptions {
 	width?: number;
@@ -33,10 +33,11 @@ export interface TextDisplayOptions extends BaseDisplayOptions {
 	fontStyle?: string;
 }
 
-export interface TileDisplayOptions extends BaseDisplayOptions {
+export type TileMapKey = string | number | symbol;
+export interface TileDisplayOptions<TChar extends TileMapKey = string> extends BaseDisplayOptions {
 	tileWidth?: number;
 	tileHeight?: number;
-	tileMap: { [key: string]: [number, number] };
+	tileMap: { [K in TChar]: [number, number] };
 	tileSet: null | HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | ImageBitmap;
 	tileColorize?: boolean;
 }

--- a/src/display/types.ts
+++ b/src/display/types.ts
@@ -1,4 +1,9 @@
-type LayoutType = "hex" | "rect" | "tile" | "tile-gl" | "term";
+export interface LayoutTypeBackendMap {
+	// Entries in this map are added via declaration merging, see the top of e.g. rect.ts
+}
+
+export type LayoutType = {[TLayout in keyof LayoutTypeBackendMap]: TLayout}[keyof LayoutTypeBackendMap];
+export type UnknownBackend = IDisplayBackend;
 
 export interface DisplayOptions {
 	width: number;
@@ -20,4 +25,100 @@ export interface DisplayOptions {
 	tileColorize: Boolean;
 }
 
-export type DisplayData = [number, number, string | string[] | null, string, string];
+import type Display from "./display.js"; // for jsdoc only
+
+/**
+ * DisplayData contains sll the information needed to draw a single cell (x,y coordinate) of the {@link Display}.
+ * The Display object is responsible for creating, keeping track of, and updating these objects, and it passes
+ * them to {@link IDisplayBackend.draw()}.
+ * 
+ * The data for a single display cell comprises, generally speaking, three things:
+ * 1. What "character" or "characters" to draw - the quotes because not all backends parse this value as an
+ *    actual text character. The tile backends, for example, only use them as index into the tileMap.
+ * 2. What style to use while drawing them, e.g. what color to use
+ * 3. What style to use for the backdrop or backdrops behind the characters
+ * 
+ * Each of these can be passed as either a single value or as an array, so each component is stored in two
+ * forms:
+ * 1. as an array whose elements are mutated with each call to the {@link Display.draw()} family of
+ *    methods: {@link chars}, {@link fgs}, {@link bgs}
+ * 2. as the actual object or value passed by the user to the appropriate parameter of the Display method:
+ * 	  {@link ch}, {@link fg}, {@link bg}
+ * 
+ * Since the arrays for the former three are created only once (the first time that cell is drawn to), this
+ * means that the draw* methods are never required to instantiate objects that will have to be garbage collected.
+ * Storing these as an object rather than array is also a slight performance optimization for the Backend's
+ * draw() method, as object destructuring assignment does not require instantiating an Iterator the way that array
+ * destructuring does.
+ */
+export interface DisplayData {
+	/** X coordinate of display cell. */
+	readonly x: number;
+	/** Y coordinate of display cell. */
+	readonly y: number;
+
+	// Normalized array forms of data
+	readonly chars: string[];
+	readonly fgs: string[];
+	readonly bgs: string[];
+
+	// User-passed data
+	ch: string | string[] | null;
+	fg: string;
+	bg: string;
+}
+
+/**
+ * This is the contract a Backend must satisfy for it to be used by a Display.
+ */
+export interface IDisplayBackend {
+	/**
+	 * Get the root-level HTMLElement containing this display, or null if this backend is unrelated to HTML
+	 */
+	getContainer(): HTMLElement | null;
+	/**
+	 * Check if this backend instance is capable of supporting the requested options. Returning false will cause the Display to construct a new one.
+	 * @param options The full (defaulted) set of options from the Display
+	 * @returns `true` if setOptions() can be called with this argument
+	 */
+	checkOptions(options: DisplayOptions): boolean;
+	/**
+	 * Set the options for this backend, and report whether a full repaint is needed.
+	 * @param options The full (defaulted) set of options from the Display
+	 * @returns `true` if the Display must do a full repaint after this
+	 */
+	setOptions(options: DisplayOptions): boolean;
+	/**
+	 * Schedule a callback at the next appropriate time to perform drawing updates.
+	 * @param cb The callback to schedule.
+	 */
+	schedule(cb: ()=>void): void;
+	/**
+	 * Clear the entire display, resetting it to the color specified by {@link DisplayOptions.bg}.
+	 */
+	clear(): void;
+	/**
+	 * Draw the specified cell.
+	 * @param data The data to draw.
+	 * @param clearBefore Whether to clear the cell to transparent prior to drawing. This will always be set if
+	 * 					  `data.bg` is not equal to {@link DisplayOptions.bg}, and also if this cell
+	 * 					  has been drawn since the last call to {@link clear()}.
+	 */
+	draw(data: DisplayData, clearBefore: boolean): void;
+	/**
+	 * Compute the maximum width/height to fit into a set of given constraints. See {@link Display.computeSize()}.
+	 */
+	computeSize(availWidth: number, availHeight: number): [number, number];
+	/**
+	 * Compute the maximum font size to fit into a set of given constraints. See {@link Display.computeFontSize()}.
+	 * If this backend does not support the concept of font size, it should throw an Error.
+	 */
+	computeFontSize(availWidth: number, availHeight: number): number;
+	/**
+	 * Convert a pair of pixel coordinates to display coordinates. See {@link Display.eventToPosition()}.
+	 * @param x The x coordinate of the event, in pixels or display-specific equivalent.
+	 * @param y The y coordinate.
+	 * @returns The zero-based x and y coordinates of the display cell at position ({@link x}, {@link y}), as a two-element array.
+	 */
+	eventToPosition(x:number, y:number): [number, number];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,18 @@
 		"strict": true,
 		"noImplicitReturns": true,
 		"noImplicitThis": true,
+		"exactOptionalPropertyTypes": true,
 		"target": "es2017",
 		"declaration": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "lib"
+		"rootDir": "./src",
+		"outDir": "lib",
+		"composite": true,
+		"newLine": "lf",
+		"sourceMap": true,
 	},
 
+	"include": ["src/**/*.ts"],
 	"files": ["src/index.ts"]
 }


### PR DESCRIPTION
This is not actually a pull request; I don't plan to take this out of draft state, as this isn't a particularly feature-rich change. This is, however, the end result of the first major bit of work I have planned, so I wanted to give you a chance to look over it and have opinions. This non-PR encompasses two changes:

## Display genericization

The TL;DR of this is that the `Display` class is now generic; it will present different capabilities depending on the options object (and most specifically its `layout` property) used to construct it. The type signature is `Display<TLayout, TChars, TFGColor, TBGColor>`, and all of these are set from the `options` parameter. For example, creating a hex-layout Display with

```ts
const dpy = new Display({layout: "hex"});
// dpy is of type Display<'hex', string[], string, string>
```

will result in a Display object whose `draw()` method is typed as:
```ts
draw(x: number, y: number, ch: string | string[] | null, fg?: string | null, bg?: string | null);
```

since the Hex backend can support multiple characters (the `string[]` TChars type argument), but only a single foreground and background color (the `string` type arguments). On the other hand, the TileGL backend supports multiple values for all three parameters, the construct signature and resulting draw() method are:
```ts
const dpy = new Display({layout: "tile-gl", /* ... */};
// dpy is of type Display<'tile-gl', string[], string[], string[]>
draw(x: number, y: number, ch: string | string[] | null, fg?: string | string[] | null, bg?: string | string[] | null);
```

Note that, when explicitly typing variables and properties, only the first type parameter, TLayout, needs to be declared, and the other three will take their default values for the given backend:
```ts
let dpy: Display<'hex'>;
// dpy is of type Display<'hex', string[], string, string>, as above
dpy = new Display(); // error, value of type Display<'rect', string[], string, string> cannot be assigned to variable
dpy = new Display({layout: "hex"}); // success
```

## Tile backend improvements

The above is _most_ of the code change involved here, and all of that was in service of being able to pull some small tweaks to the `Tile` backend from the Deiphage codebase into rot.js proper. The major one is that you can now pass a number (or array of numbers) to the `fg` parameter of Display.draw(), and they will be used as the opacity with which to draw the tile or tiles. So, the expanded signatures for the tile layout are:
```ts
let dpy: Display<'tile'>; // expanded type: Display<'tile', string[], (string | number)[], string[]>
draw(x: number,
     y: number,
     ch: string | string[] | null,
     fg?: string | number | (string | number)[] | null,
     bg?: string | string[] | null);
```

The other change is that the `Tile` and `TileGL` backends will now accept tile mappings with `symbol` or `number` keys, as well as those with `string` keys, or any combination or restriction thereof. For example, you can pass an array of [x, y] tile coordinates as the `tileMap` parameter, in which case it acts as a number-keyed map:
```ts
const dpy = new Display({
  layout: "tile",
  tileMap: [
    [0, 0], // tile 0
    [16, 0], // tile 1
    [32, 0], // tile 2
  ],
  /* ... */
});
// dpy is of type Display<'tile', number[], (string | number)[], string[]>,
// which can be abbreviated as Display<'tile', number[]>

// to draw tile 1 at 50% opacity at coordinate 3,5:
dpy.draw(3, 5, 1, 0.5);

// to draw tile 1 opaque at coordinate 5,10, with tile 2 overlaid at 25% opacity, on a red background:
dpy.draw(5, 10, [1, 2], [1, 0.25], "red");

// explicit maps will type TChars by the properties in question:
const dpy2 = new Display({
  layout:  "tile",
  tileMap: {
    "@": [0, 0],
    "f": [16, 0],
    "d": [32, 0],
  }
});
// dpy2 is of type Display<'tile', ('@' | 'f' | 'd')[], (string | number)[], string[]>
```

----

This is a fairly hefty code change, so you may want to go commit-by-commit on this one if and when you look through it; I've done my best to keep the history at least fairly coherent. And, as always, you're under no obligation, but if you do look it over, I'd certainly appreciate any feedback or thoughts!