### PR TITLE
Add github action for typos.

### DIFF
--- a/.github/workflows/typos-check.yaml
+++ b/.github/workflows/typos-check.yaml
@@ -1,0 +1,34 @@
+name: Check Typos in Source Code
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  run:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout actions repository
+        uses: actions/checkout@v4
+      - name: Check spelling of src directory.
+        uses: crate-ci/typos@master
+        with: 
+          files: './src/*'
+      - name: Check spelling of tests directory.
+        uses: crate-ci/typos@master
+        with: 
+          files: './tests/*'
+      - name: Check spelling of tools directory.
+        uses: crate-ci/typos@master
+        with: 
+          files: './tools/*'
+      - name: Check spelling of addons directory.
+        uses: crate-ci/typos@master
+        with: 
+          files: './addons/*'
+      - name: Check spelling of examples directory.
+        uses: crate-ci/typos@master
+        with: 
+          files: './examples/*'


### PR DESCRIPTION
This pull request is intended to fix #219 . By adding an extra github action containing steps to check `src`, `tests`, `tools`, `addons` and `examples` code, typos can be captured during build stage.
However, due to the action's own design, any typos found would cause the action to exit with errors. I believe this is intended to urge users to fix the typos instantly. Only way to prevent this error is submitting codes without typos.

It can't be done to make current code base go through typos checking without errors, some changes to source code must be made.